### PR TITLE
fix: Exclude empty categories from navbar

### DIFF
--- a/backend/pokedex-graphql/eslint.config.js
+++ b/backend/pokedex-graphql/eslint.config.js
@@ -26,7 +26,6 @@ export default [
       parserOptions: {
         ecmaVersion: 2020,
         sourceType: "module",
-        project: "./tsconfig.json",
       },
       globals: {
         console: "readonly",

--- a/backend/pokedex-graphql/src/datasources/pokemon-api.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.ts
@@ -1,5 +1,11 @@
 import { RESTDataSource } from "@apollo/datasource-rest";
-import { Ability, AbilityLite, Pokemon } from "../types";
+import {
+  Ability,
+  AbilityLite,
+  Pokemon,
+  PokemonRegion,
+  PokemonType,
+} from "../types";
 import {
   NamedAPIResource,
   PokemonListResponse,
@@ -7,9 +13,9 @@ import {
   PokemonAbility,
   PokemonEntity,
   TypeResponse,
+  Region,
   Pokedex,
   PokedexListResponse,
-  Region,
   RegionListResponse,
 } from "./pokemon-api.types";
 import {
@@ -35,9 +41,8 @@ export class PokemonAPI extends RESTDataSource {
     if (PokemonAPI.isIndexLoaded) return;
 
     try {
-      const response = await this.get<PokemonListResponse>(
-        "pokemon?limit=1500"
-      );
+      const response =
+        await this.get<PokemonListResponse>("pokemon?limit=1500");
       const entries = response.results;
 
       PokemonAPI.pokemonIndex = entries
@@ -208,15 +213,60 @@ export class PokemonAPI extends RESTDataSource {
     );
   }
 
-  getRegions(): Promise<string[]> {
-    return this.get<RegionListResponse>("region?limit=50").then((data) =>
-      data.results.map((entry: NamedAPIResource) => entry.name).sort()
+  getRegions(): Promise<PokemonRegion[]> {
+    return this.get<RegionListResponse>("region?limit=50").then(
+      async (data) => {
+        const regionsWithCounts = await Promise.all(
+          data.results.map(async (entry: NamedAPIResource) => {
+            try {
+              const count = await this.getPokemonByRegion(entry.name).then(
+                (pokemon) => pokemon.length
+              );
+              return {
+                name: entry.name,
+                count,
+              };
+            } catch (error) {
+              logger.error(
+                `Error getting count for region ${entry.name}:`,
+                error
+              );
+              return {
+                name: entry.name,
+                count: 0,
+              };
+            }
+          })
+        );
+
+        return regionsWithCounts.sort((a, b) => a.name.localeCompare(b.name));
+      }
     );
   }
 
-  getTypes(): Promise<string[]> {
-    return this.get<PokemonListResponse>("type?limit=50").then((data) =>
-      data.results.map((entry: NamedAPIResource) => entry.name).sort()
-    );
+  getTypes(): Promise<PokemonType[]> {
+    return this.get<PokemonListResponse>("type?limit=50").then(async (data) => {
+      const typesWithCounts = await Promise.all(
+        data.results.map(async (entry: NamedAPIResource) => {
+          try {
+            const count = await this.getPokemonByType(entry.name).then(
+              (pokemon) => pokemon.length
+            );
+            return {
+              name: entry.name,
+              count,
+            };
+          } catch (error) {
+            logger.error(`Error getting count for type ${entry.name}:`, error);
+            return {
+              name: entry.name,
+              count: 0,
+            };
+          }
+        })
+      );
+
+      return typesWithCounts.sort((a, b) => a.name.localeCompare(b.name));
+    });
   }
 }

--- a/backend/pokedex-graphql/src/jest.setup.ts
+++ b/backend/pokedex-graphql/src/jest.setup.ts
@@ -1,3 +1,4 @@
+import { beforeAll, afterAll, afterEach } from "@jest/globals";
 import { server } from "./mocks/server";
 
 // Establish API mocking before all tests

--- a/backend/pokedex-graphql/src/mocks/handlers.ts
+++ b/backend/pokedex-graphql/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { URL } from "url";
 import {
   pokemonList,
   pokemonEntity,

--- a/backend/pokedex-graphql/src/schema.graphql
+++ b/backend/pokedex-graphql/src/schema.graphql
@@ -6,7 +6,7 @@ type Query {
   pokemonByRegion(region: String, limit: Int, offset: Int): PokemonList
   ability(id: ID!): Ability
   types: [PokemonType!]!
-  pokedexes: [String!]!
+  pokedexes: [PokemonPokedex!]!
   regions: [PokemonRegion!]!
 }
 
@@ -53,6 +53,11 @@ type Ability {
 }
 
 type PokemonRegion {
+  name: String!
+  count: Int!
+}
+
+type PokemonPokedex {
   name: String!
   count: Int!
 }

--- a/backend/pokedex-graphql/src/schema.graphql
+++ b/backend/pokedex-graphql/src/schema.graphql
@@ -5,9 +5,9 @@ type Query {
   pokemonByPokedex(pokedex: String, limit: Int, offset: Int): PokemonList
   pokemonByRegion(region: String, limit: Int, offset: Int): PokemonList
   ability(id: ID!): Ability
-  types: [String!]!
+  types: [PokemonType!]!
   pokedexes: [String!]!
-  regions: [String!]!
+  regions: [PokemonRegion!]!
 }
 
 type PokemonList {
@@ -50,4 +50,14 @@ type Ability {
   effect: String!
   generation: String!
   slot: Int!
+}
+
+type PokemonRegion {
+  name: String!
+  count: Int!
+}
+
+type PokemonType {
+  name: String!
+  count: Int!
 }

--- a/backend/pokedex-graphql/src/types.ts
+++ b/backend/pokedex-graphql/src/types.ts
@@ -54,6 +54,12 @@ export type PokemonList = {
   total: Scalars['Int']['output'];
 };
 
+export type PokemonPokedex = {
+  __typename?: 'PokemonPokedex';
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type PokemonRegion = {
   __typename?: 'PokemonRegion';
   count: Scalars['Int']['output'];
@@ -69,7 +75,7 @@ export type PokemonType = {
 export type Query = {
   __typename?: 'Query';
   ability?: Maybe<Ability>;
-  pokedexes: Array<Scalars['String']['output']>;
+  pokedexes: Array<PokemonPokedex>;
   pokemon?: Maybe<Pokemon>;
   pokemonByPokedex?: Maybe<PokemonList>;
   pokemonByRegion?: Maybe<PokemonList>;
@@ -205,6 +211,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Pokemon: ResolverTypeWrapper<Pokemon>;
   PokemonList: ResolverTypeWrapper<PokemonList>;
+  PokemonPokedex: ResolverTypeWrapper<PokemonPokedex>;
   PokemonRegion: ResolverTypeWrapper<PokemonRegion>;
   PokemonType: ResolverTypeWrapper<PokemonType>;
   Query: ResolverTypeWrapper<{}>;
@@ -221,6 +228,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int']['output'];
   Pokemon: Pokemon;
   PokemonList: PokemonList;
+  PokemonPokedex: PokemonPokedex;
   PokemonRegion: PokemonRegion;
   PokemonType: PokemonType;
   Query: {};
@@ -265,6 +273,12 @@ export type PokemonListResolvers<ContextType = DataSourceContext, ParentType ext
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type PokemonPokedexResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonPokedex'] = ResolversParentTypes['PokemonPokedex']> = {
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type PokemonRegionResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonRegion'] = ResolversParentTypes['PokemonRegion']> = {
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -279,7 +293,7 @@ export type PokemonTypeResolvers<ContextType = DataSourceContext, ParentType ext
 
 export type QueryResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   ability?: Resolver<Maybe<ResolversTypes['Ability']>, ParentType, ContextType, RequireFields<QueryAbilityArgs, 'id'>>;
-  pokedexes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  pokedexes?: Resolver<Array<ResolversTypes['PokemonPokedex']>, ParentType, ContextType>;
   pokemon?: Resolver<Maybe<ResolversTypes['Pokemon']>, ParentType, ContextType, RequireFields<QueryPokemonArgs, 'id'>>;
   pokemonByPokedex?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, Partial<QueryPokemonByPokedexArgs>>;
   pokemonByRegion?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, Partial<QueryPokemonByRegionArgs>>;
@@ -304,6 +318,7 @@ export type Resolvers<ContextType = DataSourceContext> = {
   AbilityLite?: AbilityLiteResolvers<ContextType>;
   Pokemon?: PokemonResolvers<ContextType>;
   PokemonList?: PokemonListResolvers<ContextType>;
+  PokemonPokedex?: PokemonPokedexResolvers<ContextType>;
   PokemonRegion?: PokemonRegionResolvers<ContextType>;
   PokemonType?: PokemonTypeResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/backend/pokedex-graphql/src/types.ts
+++ b/backend/pokedex-graphql/src/types.ts
@@ -54,6 +54,18 @@ export type PokemonList = {
   total: Scalars['Int']['output'];
 };
 
+export type PokemonRegion = {
+  __typename?: 'PokemonRegion';
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type PokemonType = {
+  __typename?: 'PokemonType';
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   ability?: Maybe<Ability>;
@@ -63,8 +75,8 @@ export type Query = {
   pokemonByRegion?: Maybe<PokemonList>;
   pokemonByType?: Maybe<PokemonList>;
   pokemonSearch?: Maybe<PokemonList>;
-  regions: Array<Scalars['String']['output']>;
-  types: Array<Scalars['String']['output']>;
+  regions: Array<PokemonRegion>;
+  types: Array<PokemonType>;
 };
 
 
@@ -193,6 +205,8 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Pokemon: ResolverTypeWrapper<Pokemon>;
   PokemonList: ResolverTypeWrapper<PokemonList>;
+  PokemonRegion: ResolverTypeWrapper<PokemonRegion>;
+  PokemonType: ResolverTypeWrapper<PokemonType>;
   Query: ResolverTypeWrapper<{}>;
   Stats: ResolverTypeWrapper<Stats>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
@@ -207,6 +221,8 @@ export type ResolversParentTypes = {
   Int: Scalars['Int']['output'];
   Pokemon: Pokemon;
   PokemonList: PokemonList;
+  PokemonRegion: PokemonRegion;
+  PokemonType: PokemonType;
   Query: {};
   Stats: Stats;
   String: Scalars['String']['output'];
@@ -249,6 +265,18 @@ export type PokemonListResolvers<ContextType = DataSourceContext, ParentType ext
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type PokemonRegionResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonRegion'] = ResolversParentTypes['PokemonRegion']> = {
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PokemonTypeResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonType'] = ResolversParentTypes['PokemonType']> = {
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type QueryResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   ability?: Resolver<Maybe<ResolversTypes['Ability']>, ParentType, ContextType, RequireFields<QueryAbilityArgs, 'id'>>;
   pokedexes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
@@ -257,8 +285,8 @@ export type QueryResolvers<ContextType = DataSourceContext, ParentType extends R
   pokemonByRegion?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, Partial<QueryPokemonByRegionArgs>>;
   pokemonByType?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, Partial<QueryPokemonByTypeArgs>>;
   pokemonSearch?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, RequireFields<QueryPokemonSearchArgs, 'query'>>;
-  regions?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
-  types?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  regions?: Resolver<Array<ResolversTypes['PokemonRegion']>, ParentType, ContextType>;
+  types?: Resolver<Array<ResolversTypes['PokemonType']>, ParentType, ContextType>;
 };
 
 export type StatsResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['Stats'] = ResolversParentTypes['Stats']> = {
@@ -276,6 +304,8 @@ export type Resolvers<ContextType = DataSourceContext> = {
   AbilityLite?: AbilityLiteResolvers<ContextType>;
   Pokemon?: PokemonResolvers<ContextType>;
   PokemonList?: PokemonListResolvers<ContextType>;
+  PokemonRegion?: PokemonRegionResolvers<ContextType>;
+  PokemonType?: PokemonTypeResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Stats?: StatsResolvers<ContextType>;
 };

--- a/backend/pokedex-graphql/tsconfig.json
+++ b/backend/pokedex-graphql/tsconfig.json
@@ -26,6 +26,12 @@
     "typeRoots": ["../node_modules/@types", "src/@types"]
   },
   "files": ["src/graphql.d.ts"],
-  "include": ["src/**/*", "**/*.test.ts"],
-  "exclude": ["codegen.ts", "dist", "**/*.test.ts", "**/jest.setup.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/jest.setup.ts",
+    "codegen.ts"
+  ]
 }

--- a/backend/pokedex-rest/src/auth/auth.controller.spec.ts
+++ b/backend/pokedex-rest/src/auth/auth.controller.spec.ts
@@ -1,10 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthController } from './auth.controller';
+import { AuthController, AuthenticatedRequest } from './auth.controller';
 import { AuthService } from './auth.service';
 import { RegisterRequestDto } from './dtos/register-request.dto';
 import { UserEntity } from '../users/users.entity';
 import { AccessToken } from './types/AccessToken';
-
 describe('AuthController', () => {
   let controller: AuthController;
   let authService: jest.Mocked<AuthService>;
@@ -61,7 +60,9 @@ describe('AuthController', () => {
     it('should call authService.login with user from request', async () => {
       authService.login.mockResolvedValue(mockAccessToken);
 
-      const result = await controller.login(mockRequest as any);
+      const result = await controller.login(
+        mockRequest as AuthenticatedRequest,
+      );
 
       expect(authService.login).toHaveBeenCalledWith(mockUser);
       expect(result).toEqual(mockAccessToken);
@@ -71,7 +72,9 @@ describe('AuthController', () => {
       const customToken: AccessToken = { access_token: 'custom-token' };
       authService.login.mockResolvedValue(customToken);
 
-      const result = await controller.login(mockRequest as any);
+      const result = await controller.login(
+        mockRequest as AuthenticatedRequest,
+      );
 
       expect(result).toEqual(customToken);
     });

--- a/backend/pokedex-rest/src/auth/auth.controller.ts
+++ b/backend/pokedex-rest/src/auth/auth.controller.ts
@@ -15,7 +15,7 @@ import { FastifyRequest } from 'fastify';
 import { UserEntity } from '../users/users.entity';
 import { Public } from './decorators/public.decorator';
 
-interface AuthenticatedRequest extends FastifyRequest {
+export interface AuthenticatedRequest extends FastifyRequest {
   user: UserEntity;
 }
 @Public()

--- a/backend/pokedex-rest/src/main.ts
+++ b/backend/pokedex-rest/src/main.ts
@@ -74,4 +74,4 @@ async function bootstrap() {
 
   await app.listen(process.env.PORT ?? 3002, '0.0.0.0');
 }
-bootstrap();
+void bootstrap();

--- a/backend/pokedex-rest/src/users/users.service.spec.ts
+++ b/backend/pokedex-rest/src/users/users.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DeleteResult, Repository, UpdateResult } from 'typeorm';
 import { UsersService } from './users.service';
 import { UserEntity } from './users.entity';
 
@@ -162,7 +162,11 @@ describe('UsersService', () => {
       const updateData = { firstName: 'Updated', lastName: 'Name' };
       const updatedUser = { ...mockUser, ...updateData };
 
-      repository.update.mockResolvedValue({ affected: 1, raw: [] } as any);
+      repository.update.mockResolvedValue({
+        affected: 1,
+        raw: [],
+        generatedMaps: [],
+      } as UpdateResult);
       repository.findOne.mockResolvedValue(updatedUser);
 
       const result = await service.update('user-123', updateData);
@@ -177,7 +181,11 @@ describe('UsersService', () => {
     it('should return null when user not found for update', async () => {
       const updateData = { firstName: 'Updated' };
 
-      repository.update.mockResolvedValue({ affected: 0, raw: [] } as any);
+      repository.update.mockResolvedValue({
+        affected: 0,
+        raw: [],
+        generatedMaps: [],
+      } as UpdateResult);
       repository.findOne.mockResolvedValue(null);
 
       const result = await service.update('nonexistent-id', updateData);
@@ -192,7 +200,11 @@ describe('UsersService', () => {
 
   describe('delete', () => {
     it('should delete user successfully', async () => {
-      repository.delete.mockResolvedValue({ affected: 1, raw: [] } as any);
+      repository.delete.mockResolvedValue({
+        affected: 1,
+        raw: [],
+        generatedMaps: [],
+      } as DeleteResult);
 
       const result = await service.delete('user-123');
 
@@ -201,7 +213,11 @@ describe('UsersService', () => {
     });
 
     it('should return false when user not found for deletion', async () => {
-      repository.delete.mockResolvedValue({ affected: 0, raw: [] } as any);
+      repository.delete.mockResolvedValue({
+        affected: 0,
+        raw: [],
+        generatedMaps: [],
+      } as DeleteResult);
 
       const result = await service.delete('nonexistent-id');
 
@@ -210,7 +226,10 @@ describe('UsersService', () => {
     });
 
     it('should handle undefined affected value', async () => {
-      repository.delete.mockResolvedValue({ raw: [] } as any);
+      repository.delete.mockResolvedValue({
+        raw: [],
+        generatedMaps: [],
+      } as DeleteResult);
 
       const result = await service.delete('user-123');
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Suspense } from "react";
 import ApolloWrapper from "@/ui/ApolloWrapper";
 import QueryProvider from "./providers/QueryProvider";
+import NavigationDataProvider from "./providers/NavigationDataProvider";
 import { SearchBar } from "@/ui/Search";
 import AuthButtons from "@/ui/AuthButtons";
 import Navbar from "@/ui/Navbar";
@@ -23,11 +25,13 @@ export const metadata: Metadata = {
   description: "A Pokémon database with GraphQL API",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const navigationData = await NavigationDataProvider();
+
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
@@ -36,11 +40,17 @@ export default function RootLayout({
             <div className={styles.container}>
               <header className={styles.header}>
                 <h1 className={styles.heading}>Pokédex</h1>
-                <SearchBar />
-                <AuthButtons />
+                <Suspense fallback={<div>Loading search...</div>}>
+                  <SearchBar />
+                </Suspense>
+                <Suspense fallback={<div>Loading auth...</div>}>
+                  <AuthButtons />
+                </Suspense>
               </header>
               <div className={styles.content}>
-                <Navbar />
+                <Suspense fallback={<div>Loading navigation...</div>}>
+                  <Navbar navigationData={navigationData} />
+                </Suspense>
                 <main className={styles.main}>{children}</main>
               </div>
             </div>

--- a/frontend/app/lib/queries.ts
+++ b/frontend/app/lib/queries.ts
@@ -2,7 +2,10 @@ import { gql } from "@apollo/client";
 
 export const GET_TYPES = gql`
   query GetTypes {
-    types
+    types {
+      name
+      count
+    }
   }
 `;
 
@@ -104,7 +107,10 @@ export const GET_POKEMON_BY_POKEDEX = gql`
 
 export const GET_REGIONS = gql`
   query GetRegions {
-    regions
+    regions {
+      name
+      count
+    }
   }
 `;
 

--- a/frontend/app/lib/queries.ts
+++ b/frontend/app/lib/queries.ts
@@ -71,7 +71,10 @@ export const SEARCH_POKEMON = gql`
 
 export const GET_POKEDEXES = gql`
   query GetPokedexes {
-    pokedexes
+    pokedexes {
+      name
+      count
+    }
   }
 `;
 

--- a/frontend/app/lib/string.test.ts
+++ b/frontend/app/lib/string.test.ts
@@ -1,0 +1,29 @@
+import { capitalize } from "./string";
+
+describe("capitalize", () => {
+  it("should capitalize the first character of a string", () => {
+    expect(capitalize("hello")).toBe("Hello");
+    expect(capitalize("world")).toBe("World");
+    expect(capitalize("pokemon")).toBe("Pokemon");
+  });
+
+  it("should handle single character strings", () => {
+    expect(capitalize("a")).toBe("A");
+    expect(capitalize("z")).toBe("Z");
+  });
+
+  it("should handle already capitalized strings", () => {
+    expect(capitalize("Hello")).toBe("Hello");
+    expect(capitalize("WORLD")).toBe("WORLD");
+  });
+
+  it("should handle empty string", () => {
+    expect(capitalize("")).toBe("");
+  });
+
+  it("should handle strings with special characters", () => {
+    expect(capitalize("hello-world")).toBe("Hello-world");
+    expect(capitalize("123abc")).toBe("123abc");
+    expect(capitalize("!hello")).toBe("!hello");
+  });
+});

--- a/frontend/app/lib/string.ts
+++ b/frontend/app/lib/string.ts
@@ -1,0 +1,9 @@
+/**
+ * Capitalizes the first character of a string
+ * @param str - The string to capitalize
+ * @returns The string with the first character capitalized
+ */
+export const capitalize = (str: string): string => {
+  if (!str || str.length === 0) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -47,6 +47,16 @@ export type PokemonList = {
   total: Scalars['Int']['output'];
 };
 
+export type PokemonRegion = {
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type PokemonType = {
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type Query = {
   ability?: Maybe<Ability>;
   pokedexes: Array<Scalars['String']['output']>;
@@ -55,8 +65,8 @@ export type Query = {
   pokemonByRegion?: Maybe<PokemonList>;
   pokemonByType?: Maybe<PokemonList>;
   pokemonSearch?: Maybe<PokemonList>;
-  regions: Array<Scalars['String']['output']>;
-  types: Array<Scalars['String']['output']>;
+  regions: Array<PokemonRegion>;
+  types: Array<PokemonType>;
 };
 
 

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -47,6 +47,11 @@ export type PokemonList = {
   total: Scalars['Int']['output'];
 };
 
+export type PokemonPokedex = {
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type PokemonRegion = {
   count: Scalars['Int']['output'];
   name: Scalars['String']['output'];
@@ -59,7 +64,7 @@ export type PokemonType = {
 
 export type Query = {
   ability?: Maybe<Ability>;
-  pokedexes: Array<Scalars['String']['output']>;
+  pokedexes: Array<PokemonPokedex>;
   pokemon?: Maybe<Pokemon>;
   pokemonByPokedex?: Maybe<PokemonList>;
   pokemonByRegion?: Maybe<PokemonList>;

--- a/frontend/app/lib/validation.ts
+++ b/frontend/app/lib/validation.ts
@@ -57,15 +57,3 @@ export function validateEmail(email: string): boolean {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 }
-
-export function validateUsername(username: string): boolean {
-  // Username should be 3-20 characters, alphanumeric and underscores only
-  const usernameRegex = /^[a-zA-Z0-9_]{3,20}$/;
-  return usernameRegex.test(username);
-}
-
-export function validateName(name: string): boolean {
-  // Name should be 2-50 characters, letters and spaces only
-  const nameRegex = /^[a-zA-Z\s]{2,50}$/;
-  return nameRegex.test(name);
-}

--- a/frontend/app/providers/NavigationDataProvider.test.ts
+++ b/frontend/app/providers/NavigationDataProvider.test.ts
@@ -1,0 +1,372 @@
+import { client } from "../lib/apollo-client";
+import { getTypes, getPokedexes, getRegions } from "./NavigationDataProvider";
+import NavigationDataProvider from "./NavigationDataProvider";
+import { PokemonType, PokemonRegion } from "../lib/types";
+
+// Mock the Apollo client
+jest.mock("../lib/apollo-client", () => ({
+  client: {
+    query: jest.fn(),
+  },
+}));
+
+const mockClient = client as jest.Mocked<typeof client>;
+
+// Helper type for mock query results
+type MockQueryResult<T> = never;
+
+describe("NavigationDataProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getTypes", () => {
+    it("should fetch types and filter out those with count 0", async () => {
+      const mockTypes: PokemonType[] = [
+        { name: "fire", count: 5 },
+        { name: "water", count: 0 },
+        { name: "grass", count: 3 },
+        { name: "electric", count: 0 },
+        { name: "psychic", count: 2 },
+      ];
+
+      mockClient.query.mockResolvedValue({
+        data: { types: mockTypes },
+      } as MockQueryResult<{ types: PokemonType[] }>);
+
+      const result = await getTypes();
+
+      expect(mockClient.query).toHaveBeenCalledWith({
+        query: expect.any(Object),
+      });
+      expect(result).toEqual([
+        { name: "fire", count: 5 },
+        { name: "grass", count: 3 },
+        { name: "psychic", count: 2 },
+      ]);
+    });
+
+    it("should return empty array when no types have count > 0", async () => {
+      const mockTypes: PokemonType[] = [
+        { name: "fire", count: 0 },
+        { name: "water", count: 0 },
+        { name: "grass", count: 0 },
+      ];
+
+      mockClient.query.mockResolvedValue({
+        data: { types: mockTypes },
+      } as MockQueryResult<{ types: PokemonType[] }>);
+
+      const result = await getTypes();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when types data is undefined", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { types: undefined },
+      } as MockQueryResult<{ types: PokemonType[] | undefined }>);
+
+      const result = await getTypes();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when types data is null", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { types: null },
+      } as MockQueryResult<{ types: PokemonType[] | null }>);
+
+      const result = await getTypes();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle errors gracefully and return empty array", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      mockClient.query.mockRejectedValue(new Error("Network error"));
+
+      const result = await getTypes();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error fetching types:",
+        expect.any(Error)
+      );
+      expect(result).toEqual([]);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle empty types array", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { types: [] },
+      } as MockQueryResult<{ types: PokemonType[] }>);
+
+      const result = await getTypes();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getPokedexes", () => {
+    it("should fetch pokedexes successfully", async () => {
+      const mockPokedexes = ["national", "kanto", "johto", "hoenn"];
+
+      mockClient.query.mockResolvedValue({
+        data: { pokedexes: mockPokedexes },
+      } as MockQueryResult<{ pokedexes: string[] }>);
+
+      const result = await getPokedexes();
+
+      expect(mockClient.query).toHaveBeenCalledWith({
+        query: expect.any(Object), // GraphQL query object
+      });
+      expect(result).toEqual(mockPokedexes);
+    });
+
+    it("should return empty array when pokedexes data is undefined", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { pokedexes: undefined },
+      } as MockQueryResult<{ pokedexes: string[] | undefined }>);
+
+      const result = await getPokedexes();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when pokedexes data is null", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { pokedexes: null },
+      } as MockQueryResult<{ pokedexes: string[] | null }>);
+
+      const result = await getPokedexes();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle errors gracefully and return empty array", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      mockClient.query.mockRejectedValue(new Error("Network error"));
+
+      const result = await getPokedexes();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error fetching pokedexes:",
+        expect.any(Error)
+      );
+      expect(result).toEqual([]);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle empty pokedexes array", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { pokedexes: [] },
+      } as MockQueryResult<{ pokedexes: string[] }>);
+
+      const result = await getPokedexes();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getRegions", () => {
+    it("should fetch regions and filter out those with count 0", async () => {
+      const mockRegions: PokemonRegion[] = [
+        { name: "kanto", count: 151 },
+        { name: "johto", count: 0 },
+        { name: "hoenn", count: 135 },
+        { name: "sinnoh", count: 0 },
+        { name: "unova", count: 156 },
+      ];
+
+      mockClient.query.mockResolvedValue({
+        data: { regions: mockRegions },
+      } as MockQueryResult<{ regions: PokemonRegion[] }>);
+
+      const result = await getRegions();
+
+      expect(mockClient.query).toHaveBeenCalledWith({
+        query: expect.any(Object), 
+      });
+      expect(result).toEqual([
+        { name: "kanto", count: 151 },
+        { name: "hoenn", count: 135 },
+        { name: "unova", count: 156 },
+      ]);
+    });
+
+    it("should return empty array when no regions have count > 0", async () => {
+      const mockRegions: PokemonRegion[] = [
+        { name: "kanto", count: 0 },
+        { name: "johto", count: 0 },
+        { name: "hoenn", count: 0 },
+      ];
+
+      mockClient.query.mockResolvedValue({
+        data: { regions: mockRegions },
+      } as MockQueryResult<{ regions: PokemonRegion[] }>);
+
+      const result = await getRegions();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when regions data is undefined", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { regions: undefined },
+      } as MockQueryResult<{ regions: PokemonRegion[] | undefined }>);
+
+      const result = await getRegions();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when regions data is null", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { regions: null },
+      } as MockQueryResult<{ regions: PokemonRegion[] | null }>);
+
+      const result = await getRegions();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle errors gracefully and return empty array", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      mockClient.query.mockRejectedValue(new Error("Network error"));
+
+      const result = await getRegions();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error fetching regions:",
+        expect.any(Error)
+      );
+      expect(result).toEqual([]);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle empty regions array", async () => {
+      mockClient.query.mockResolvedValue({
+        data: { regions: [] },
+      } as MockQueryResult<{ regions: PokemonRegion[] }>);
+
+      const result = await getRegions();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("NavigationDataProvider", () => {
+    it("should fetch all data concurrently and return combined result", async () => {
+      const mockTypes: PokemonType[] = [
+        { name: "fire", count: 5 },
+        { name: "water", count: 3 },
+      ];
+      const mockPokedexes = ["national", "kanto"];
+      const mockRegions: PokemonRegion[] = [
+        { name: "kanto", count: 151 },
+        { name: "johto", count: 100 },
+      ];
+
+      // Mock all three queries
+      mockClient.query
+        .mockResolvedValueOnce({
+          data: { types: mockTypes },
+        } as MockQueryResult<{ types: PokemonType[] }>)
+        .mockResolvedValueOnce({
+          data: { pokedexes: mockPokedexes },
+        } as MockQueryResult<{ pokedexes: string[] }>)
+        .mockResolvedValueOnce({
+          data: { regions: mockRegions },
+        } as MockQueryResult<{ regions: PokemonRegion[] }>);
+
+      const result = await NavigationDataProvider();
+
+      expect(mockClient.query).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({
+        types: mockTypes,
+        pokedexes: mockPokedexes,
+        regions: mockRegions,
+      });
+    });
+
+    it("should handle mixed data with filtering applied", async () => {
+      const mockTypes: PokemonType[] = [
+        { name: "fire", count: 5 },
+        { name: "water", count: 0 }, // Should be filtered out
+        { name: "grass", count: 3 },
+      ];
+      const mockPokedexes = ["national", "kanto"];
+      const mockRegions: PokemonRegion[] = [
+        { name: "kanto", count: 151 },
+        { name: "johto", count: 0 }, // Should be filtered out
+        { name: "hoenn", count: 135 },
+      ];
+
+      // Mock all three queries
+      mockClient.query
+        .mockResolvedValueOnce({
+          data: { types: mockTypes },
+        } as MockQueryResult<{ types: PokemonType[] }>)
+        .mockResolvedValueOnce({
+          data: { pokedexes: mockPokedexes },
+        } as MockQueryResult<{ pokedexes: string[] }>)
+        .mockResolvedValueOnce({
+          data: { regions: mockRegions },
+        } as MockQueryResult<{ regions: PokemonRegion[] }>);
+
+      const result = await NavigationDataProvider();
+
+      expect(result).toEqual({
+        types: [
+          { name: "fire", count: 5 },
+          { name: "grass", count: 3 },
+        ],
+        pokedexes: ["national", "kanto"],
+        regions: [
+          { name: "kanto", count: 151 },
+          { name: "hoenn", count: 135 },
+        ],
+      });
+    });
+
+    it("should handle errors in individual queries gracefully", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const mockTypes: PokemonType[] = [{ name: "fire", count: 5 }];
+
+      // Mock successful types query, failed pokedexes query, successful regions query
+      mockClient.query
+        .mockResolvedValueOnce({
+          data: { types: mockTypes },
+        } as MockQueryResult<{ types: PokemonType[] }>)
+        .mockRejectedValueOnce(new Error("Pokedexes error"))
+        .mockResolvedValueOnce({ data: { regions: [] } } as MockQueryResult<{
+          regions: PokemonRegion[];
+        }>);
+
+      const result = await NavigationDataProvider();
+
+      expect(result).toEqual({
+        types: mockTypes,
+        pokedexes: [],
+        regions: [],
+      });
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/frontend/app/providers/NavigationDataProvider.test.ts
+++ b/frontend/app/providers/NavigationDataProvider.test.ts
@@ -1,7 +1,7 @@
 import { client } from "../lib/apollo-client";
 import { getTypes, getPokedexes, getRegions } from "./NavigationDataProvider";
 import NavigationDataProvider from "./NavigationDataProvider";
-import { PokemonType, PokemonRegion } from "../lib/types";
+import { PokemonType, PokemonRegion, PokemonPokedex } from "../lib/types";
 
 // Mock the Apollo client
 jest.mock("../lib/apollo-client", () => ({
@@ -113,11 +113,16 @@ describe("NavigationDataProvider", () => {
 
   describe("getPokedexes", () => {
     it("should fetch pokedexes successfully", async () => {
-      const mockPokedexes = ["national", "kanto", "johto", "hoenn"];
+      const mockPokedexes: PokemonPokedex[] = [
+        { name: "national", count: 1008 },
+        { name: "kanto", count: 151 },
+        { name: "johto", count: 100 },
+        { name: "hoenn", count: 135 },
+      ];
 
       mockClient.query.mockResolvedValue({
         data: { pokedexes: mockPokedexes },
-      } as MockQueryResult<{ pokedexes: string[] }>);
+      } as MockQueryResult<{ pokedexes: PokemonPokedex[] }>);
 
       const result = await getPokedexes();
 
@@ -130,7 +135,7 @@ describe("NavigationDataProvider", () => {
     it("should return empty array when pokedexes data is undefined", async () => {
       mockClient.query.mockResolvedValue({
         data: { pokedexes: undefined },
-      } as MockQueryResult<{ pokedexes: string[] | undefined }>);
+      } as MockQueryResult<{ pokedexes: PokemonPokedex[] | undefined }>);
 
       const result = await getPokedexes();
 
@@ -140,7 +145,7 @@ describe("NavigationDataProvider", () => {
     it("should return empty array when pokedexes data is null", async () => {
       mockClient.query.mockResolvedValue({
         data: { pokedexes: null },
-      } as MockQueryResult<{ pokedexes: string[] | null }>);
+      } as MockQueryResult<{ pokedexes: PokemonPokedex[] | null }>);
 
       const result = await getPokedexes();
 
@@ -168,11 +173,33 @@ describe("NavigationDataProvider", () => {
     it("should handle empty pokedexes array", async () => {
       mockClient.query.mockResolvedValue({
         data: { pokedexes: [] },
-      } as MockQueryResult<{ pokedexes: string[] }>);
+      } as MockQueryResult<{ pokedexes: PokemonPokedex[] }>);
 
       const result = await getPokedexes();
 
       expect(result).toEqual([]);
+    });
+
+    it("should filter out pokedexes with count 0", async () => {
+      const mockPokedexes: PokemonPokedex[] = [
+        { name: "national", count: 1008 },
+        { name: "kanto", count: 0 },
+        { name: "johto", count: 100 },
+        { name: "hoenn", count: 0 },
+        { name: "sinnoh", count: 107 },
+      ];
+
+      mockClient.query.mockResolvedValue({
+        data: { pokedexes: mockPokedexes },
+      } as MockQueryResult<{ pokedexes: PokemonPokedex[] }>);
+
+      const result = await getPokedexes();
+
+      expect(result).toEqual([
+        { name: "national", count: 1008 },
+        { name: "johto", count: 100 },
+        { name: "sinnoh", count: 107 },
+      ]);
     });
   });
 
@@ -193,7 +220,7 @@ describe("NavigationDataProvider", () => {
       const result = await getRegions();
 
       expect(mockClient.query).toHaveBeenCalledWith({
-        query: expect.any(Object), 
+        query: expect.any(Object),
       });
       expect(result).toEqual([
         { name: "kanto", count: 151 },
@@ -273,7 +300,10 @@ describe("NavigationDataProvider", () => {
         { name: "fire", count: 5 },
         { name: "water", count: 3 },
       ];
-      const mockPokedexes = ["national", "kanto"];
+      const mockPokedexes: PokemonPokedex[] = [
+        { name: "national", count: 1008 },
+        { name: "kanto", count: 151 },
+      ];
       const mockRegions: PokemonRegion[] = [
         { name: "kanto", count: 151 },
         { name: "johto", count: 100 },
@@ -286,7 +316,7 @@ describe("NavigationDataProvider", () => {
         } as MockQueryResult<{ types: PokemonType[] }>)
         .mockResolvedValueOnce({
           data: { pokedexes: mockPokedexes },
-        } as MockQueryResult<{ pokedexes: string[] }>)
+        } as MockQueryResult<{ pokedexes: PokemonPokedex[] }>)
         .mockResolvedValueOnce({
           data: { regions: mockRegions },
         } as MockQueryResult<{ regions: PokemonRegion[] }>);
@@ -307,7 +337,11 @@ describe("NavigationDataProvider", () => {
         { name: "water", count: 0 }, // Should be filtered out
         { name: "grass", count: 3 },
       ];
-      const mockPokedexes = ["national", "kanto"];
+      const mockPokedexes: PokemonPokedex[] = [
+        { name: "national", count: 1008 },
+        { name: "kanto", count: 0 },
+        { name: "johto", count: 100 },
+      ];
       const mockRegions: PokemonRegion[] = [
         { name: "kanto", count: 151 },
         { name: "johto", count: 0 }, // Should be filtered out
@@ -321,7 +355,7 @@ describe("NavigationDataProvider", () => {
         } as MockQueryResult<{ types: PokemonType[] }>)
         .mockResolvedValueOnce({
           data: { pokedexes: mockPokedexes },
-        } as MockQueryResult<{ pokedexes: string[] }>)
+        } as MockQueryResult<{ pokedexes: PokemonPokedex[] }>)
         .mockResolvedValueOnce({
           data: { regions: mockRegions },
         } as MockQueryResult<{ regions: PokemonRegion[] }>);
@@ -333,7 +367,10 @@ describe("NavigationDataProvider", () => {
           { name: "fire", count: 5 },
           { name: "grass", count: 3 },
         ],
-        pokedexes: ["national", "kanto"],
+        pokedexes: [
+          { name: "national", count: 1008 },
+          { name: "johto", count: 100 },
+        ],
         regions: [
           { name: "kanto", count: 151 },
           { name: "hoenn", count: 135 },

--- a/frontend/app/providers/NavigationDataProvider.tsx
+++ b/frontend/app/providers/NavigationDataProvider.tsx
@@ -1,10 +1,10 @@
-import { PokemonType, PokemonRegion } from "@/lib/types";
+import { PokemonType, PokemonRegion, PokemonPokedex } from "@/lib/types";
 import { client } from "@/lib/apollo-client";
 import { GET_TYPES, GET_POKEDEXES, GET_REGIONS } from "@/lib/queries";
 
 export interface NavigationData {
   types: PokemonType[];
-  pokedexes: string[];
+  pokedexes: PokemonPokedex[];
   regions: PokemonRegion[];
 }
 
@@ -20,12 +20,12 @@ export const getTypes = async (): Promise<PokemonType[]> => {
   }
 };
 
-export const getPokedexes = async (): Promise<string[]> => {
+export const getPokedexes = async (): Promise<PokemonPokedex[]> => {
   try {
-    const { data } = await client.query<{ pokedexes: string[] }>({
+    const { data } = await client.query<{ pokedexes: PokemonPokedex[] }>({
       query: GET_POKEDEXES,
     });
-    return data.pokedexes || [];
+    return data.pokedexes?.filter((pokedex) => pokedex.count > 0) || [];
   } catch (error) {
     console.error("Error fetching pokedexes:", error);
     return [];

--- a/frontend/app/providers/NavigationDataProvider.tsx
+++ b/frontend/app/providers/NavigationDataProvider.tsx
@@ -1,0 +1,55 @@
+import { PokemonType, PokemonRegion } from "@/lib/types";
+import { client } from "@/lib/apollo-client";
+import { GET_TYPES, GET_POKEDEXES, GET_REGIONS } from "@/lib/queries";
+
+export interface NavigationData {
+  types: PokemonType[];
+  pokedexes: string[];
+  regions: PokemonRegion[];
+}
+
+export const getTypes = async (): Promise<PokemonType[]> => {
+  try {
+    const { data } = await client.query<{ types: PokemonType[] }>({
+      query: GET_TYPES,
+    });
+    return data.types?.filter((type) => type.count > 0) || [];
+  } catch (error) {
+    console.error("Error fetching types:", error);
+    return [];
+  }
+};
+
+export const getPokedexes = async (): Promise<string[]> => {
+  try {
+    const { data } = await client.query<{ pokedexes: string[] }>({
+      query: GET_POKEDEXES,
+    });
+    return data.pokedexes || [];
+  } catch (error) {
+    console.error("Error fetching pokedexes:", error);
+    return [];
+  }
+};
+
+export const getRegions = async (): Promise<PokemonRegion[]> => {
+  try {
+    const { data } = await client.query<{ regions: PokemonRegion[] }>({
+      query: GET_REGIONS,
+    });
+    return data.regions?.filter((region) => region.count > 0) || [];
+  } catch (error) {
+    console.error("Error fetching regions:", error);
+    return [];
+  }
+};
+
+export default async function NavigationDataProvider() {
+  const [types, pokedexes, regions] = await Promise.all([
+    getTypes(),
+    getPokedexes(),
+    getRegions(),
+  ]);
+
+  return { types, pokedexes, regions };
+}

--- a/frontend/app/ui/Navbar/Navbar.tsx
+++ b/frontend/app/ui/Navbar/Navbar.tsx
@@ -1,16 +1,17 @@
 import { GET_TYPES, GET_POKEDEXES, GET_REGIONS } from "@/lib/queries";
 import { client } from "@/lib/apollo-client";
+import { PokemonType, PokemonRegion } from "@/lib/types";
 import NavbarSection from "./NavbarSection";
 import { NavItem } from "./NavbarItem";
 
 import styles from "./Navbar.module.css";
 
-async function getTypes(): Promise<string[]> {
+async function getTypes(): Promise<PokemonType[]> {
   try {
-    const { data } = await client.query<{ types: string[] }>({
+    const { data } = await client.query<{ types: PokemonType[] }>({
       query: GET_TYPES,
     });
-    return data.types || [];
+    return data.types.filter((type) => type.count > 0) || [];
   } catch (error) {
     console.error("Error fetching types:", error);
     return [];
@@ -29,12 +30,12 @@ async function getPokedexes(): Promise<string[]> {
   }
 }
 
-async function getRegions(): Promise<string[]> {
+async function getRegions(): Promise<PokemonRegion[]> {
   try {
-    const { data } = await client.query<{ regions: string[] }>({
+    const { data } = await client.query<{ regions: PokemonRegion[] }>({
       query: GET_REGIONS,
     });
-    return data.regions || [];
+    return data.regions.filter((region) => region.count > 0) || [];
   } catch (error) {
     console.error("Error fetching regions:", error);
     return [];
@@ -49,9 +50,9 @@ export default async function Navbar() {
   ]);
 
   const typeItems: NavItem[] = types.map((type) => ({
-    label: type.charAt(0).toUpperCase() + type.slice(1),
-    href: `/?type=${encodeURIComponent(type)}`,
-    activeWhenQueryParamEquals: { key: "type", value: type },
+    label: `${type.name.charAt(0).toUpperCase()}${type.name.slice(1)} (${type.count})`,
+    href: `/?type=${encodeURIComponent(type.name)}`,
+    activeWhenQueryParamEquals: { key: "type", value: type.name },
   }));
 
   const pokedexItems: NavItem[] = pokedexes.map((pokedex) => ({
@@ -62,9 +63,9 @@ export default async function Navbar() {
   }));
 
   const regionItems: NavItem[] = regions.map((region) => ({
-    label: region.charAt(0).toUpperCase() + region.slice(1),
-    href: `/?region=${encodeURIComponent(region)}`,
-    activeWhenQueryParamEquals: { key: "region", value: region },
+    label: `${region.name.charAt(0).toUpperCase()}${region.name.slice(1)} (${region.count})`,
+    href: `/?region=${encodeURIComponent(region.name)}`,
+    activeWhenQueryParamEquals: { key: "region", value: region.name },
   }));
 
   const specialItems: NavItem[] = [

--- a/frontend/app/ui/Navbar/Navbar.tsx
+++ b/frontend/app/ui/Navbar/Navbar.tsx
@@ -1,85 +1,26 @@
-import { GET_TYPES, GET_POKEDEXES, GET_REGIONS } from "@/lib/queries";
-import { client } from "@/lib/apollo-client";
-import { PokemonType, PokemonRegion } from "@/lib/types";
+import { useMemo } from "react";
+import { NavigationData } from "@/providers/NavigationDataProvider";
+import {
+  getTypeItems,
+  getSpecialItems,
+  getRegionItems,
+  getPokedexItems,
+} from "./Navbar.util";
 import NavbarSection from "./NavbarSection";
-import { NavItem } from "./NavbarItem";
 
 import styles from "./Navbar.module.css";
 
-async function getTypes(): Promise<PokemonType[]> {
-  try {
-    const { data } = await client.query<{ types: PokemonType[] }>({
-      query: GET_TYPES,
-    });
-    return data.types.filter((type) => type.count > 0) || [];
-  } catch (error) {
-    console.error("Error fetching types:", error);
-    return [];
-  }
+interface NavbarProps {
+  navigationData: NavigationData;
 }
 
-async function getPokedexes(): Promise<string[]> {
-  try {
-    const { data } = await client.query<{ pokedexes: string[] }>({
-      query: GET_POKEDEXES,
-    });
-    return data.pokedexes || [];
-  } catch (error) {
-    console.error("Error fetching pokedexes:", error);
-    return [];
-  }
-}
+export default function Navbar({ navigationData }: NavbarProps) {
+  const { types, pokedexes, regions } = navigationData;
 
-async function getRegions(): Promise<PokemonRegion[]> {
-  try {
-    const { data } = await client.query<{ regions: PokemonRegion[] }>({
-      query: GET_REGIONS,
-    });
-    return data.regions.filter((region) => region.count > 0) || [];
-  } catch (error) {
-    console.error("Error fetching regions:", error);
-    return [];
-  }
-}
-
-export default async function Navbar() {
-  const [types, pokedexes, regions] = await Promise.all([
-    getTypes(),
-    getPokedexes(),
-    getRegions(),
-  ]);
-
-  const typeItems: NavItem[] = types.map((type) => ({
-    label: `${type.name.charAt(0).toUpperCase()}${type.name.slice(1)} (${type.count})`,
-    href: `/?type=${encodeURIComponent(type.name)}`,
-    activeWhenQueryParamEquals: { key: "type", value: type.name },
-  }));
-
-  const pokedexItems: NavItem[] = pokedexes.map((pokedex) => ({
-    label:
-      pokedex.charAt(0).toUpperCase() + pokedex.slice(1).replace(/-/g, " "),
-    href: `/?pokedex=${encodeURIComponent(pokedex)}`,
-    activeWhenQueryParamEquals: { key: "pokedex", value: pokedex },
-  }));
-
-  const regionItems: NavItem[] = regions.map((region) => ({
-    label: `${region.name.charAt(0).toUpperCase()}${region.name.slice(1)} (${region.count})`,
-    href: `/?region=${encodeURIComponent(region.name)}`,
-    activeWhenQueryParamEquals: { key: "region", value: region.name },
-  }));
-
-  const specialItems: NavItem[] = [
-    {
-      label: "Gigantamax",
-      href: "/?q=gmax",
-      activeWhenQueryParamEquals: { key: "query", value: "gmax" },
-    },
-    {
-      label: "Mega Evolve",
-      href: "/?q=-mega",
-      activeWhenQueryParamEquals: { key: "query", value: "mega" },
-    },
-  ];
+  const typeItems = useMemo(() => getTypeItems(types), [types]);
+  const specialItems = useMemo(() => getSpecialItems(), []);
+  const regionItems = useMemo(() => getRegionItems(regions), [regions]);
+  const pokedexItems = useMemo(() => getPokedexItems(pokedexes), [pokedexes]);
 
   return (
     <nav className={styles.navbar}>

--- a/frontend/app/ui/Navbar/Navbar.util.tsx
+++ b/frontend/app/ui/Navbar/Navbar.util.tsx
@@ -1,4 +1,4 @@
-import { PokemonType, PokemonRegion } from "@/lib/types";
+import { PokemonType, PokemonRegion, PokemonPokedex } from "@/lib/types";
 import { NavItem } from "./NavbarItem";
 import { capitalize } from "@/lib/string";
 
@@ -9,11 +9,11 @@ export const getTypeItems = (types: PokemonType[]): NavItem[] =>
     activeWhenQueryParamEquals: { key: "type", value: type.name },
   }));
 
-export const getPokedexItems = (pokedexes: string[]): NavItem[] =>
+export const getPokedexItems = (pokedexes: PokemonPokedex[]): NavItem[] =>
   pokedexes.map((pokedex) => ({
-    label: capitalize(pokedex).replace(/-/g, " "),
-    href: `/?pokedex=${encodeURIComponent(pokedex)}`,
-    activeWhenQueryParamEquals: { key: "pokedex", value: pokedex },
+    label: `${capitalize(pokedex.name).replace(/-/g, " ")} (${pokedex.count})`,
+    href: `/?pokedex=${encodeURIComponent(pokedex.name)}`,
+    activeWhenQueryParamEquals: { key: "pokedex", value: pokedex.name },
   }));
 
 export const getRegionItems = (regions: PokemonRegion[]): NavItem[] =>

--- a/frontend/app/ui/Navbar/Navbar.util.tsx
+++ b/frontend/app/ui/Navbar/Navbar.util.tsx
@@ -1,0 +1,37 @@
+import { PokemonType, PokemonRegion } from "@/lib/types";
+import { NavItem } from "./NavbarItem";
+
+export const getTypeItems = (types: PokemonType[]): NavItem[] =>
+  types.map((type) => ({
+    label: `${type.name.charAt(0).toUpperCase()}${type.name.slice(1)} (${type.count})`,
+    href: `/?type=${encodeURIComponent(type.name)}`,
+    activeWhenQueryParamEquals: { key: "type", value: type.name },
+  }));
+
+export const getPokedexItems = (pokedexes: string[]): NavItem[] =>
+  pokedexes.map((pokedex) => ({
+    label:
+      pokedex.charAt(0).toUpperCase() + pokedex.slice(1).replace(/-/g, " "),
+    href: `/?pokedex=${encodeURIComponent(pokedex)}`,
+    activeWhenQueryParamEquals: { key: "pokedex", value: pokedex },
+  }));
+
+export const getRegionItems = (regions: PokemonRegion[]): NavItem[] =>
+  regions.map((region) => ({
+    label: `${region.name.charAt(0).toUpperCase()}${region.name.slice(1)} (${region.count})`,
+    href: `/?region=${encodeURIComponent(region.name)}`,
+    activeWhenQueryParamEquals: { key: "region", value: region.name },
+  }));
+
+export const getSpecialItems = (): NavItem[] => [
+  {
+    label: "Gigantamax",
+    href: "/?q=gmax",
+    activeWhenQueryParamEquals: { key: "query", value: "gmax" },
+  },
+  {
+    label: "Mega Evolve",
+    href: "/?q=-mega",
+    activeWhenQueryParamEquals: { key: "query", value: "mega" },
+  },
+];

--- a/frontend/app/ui/Navbar/Navbar.util.tsx
+++ b/frontend/app/ui/Navbar/Navbar.util.tsx
@@ -1,24 +1,24 @@
 import { PokemonType, PokemonRegion } from "@/lib/types";
 import { NavItem } from "./NavbarItem";
+import { capitalize } from "@/lib/string";
 
 export const getTypeItems = (types: PokemonType[]): NavItem[] =>
   types.map((type) => ({
-    label: `${type.name.charAt(0).toUpperCase()}${type.name.slice(1)} (${type.count})`,
+    label: `${capitalize(type.name)} (${type.count})`,
     href: `/?type=${encodeURIComponent(type.name)}`,
     activeWhenQueryParamEquals: { key: "type", value: type.name },
   }));
 
 export const getPokedexItems = (pokedexes: string[]): NavItem[] =>
   pokedexes.map((pokedex) => ({
-    label:
-      pokedex.charAt(0).toUpperCase() + pokedex.slice(1).replace(/-/g, " "),
+    label: capitalize(pokedex).replace(/-/g, " "),
     href: `/?pokedex=${encodeURIComponent(pokedex)}`,
     activeWhenQueryParamEquals: { key: "pokedex", value: pokedex },
   }));
 
 export const getRegionItems = (regions: PokemonRegion[]): NavItem[] =>
   regions.map((region) => ({
-    label: `${region.name.charAt(0).toUpperCase()}${region.name.slice(1)} (${region.count})`,
+    label: `${capitalize(region.name)} (${region.count})`,
     href: `/?region=${encodeURIComponent(region.name)}`,
     activeWhenQueryParamEquals: { key: "region", value: region.name },
   }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
       }
     },
     "backend/pokedex-graphql": {
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",
@@ -93,7 +93,7 @@
       }
     },
     "backend/pokedex-rest": {
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -650,7 +650,7 @@
     },
     "frontend": {
       "name": "pokedex-frontend",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@tanstack/react-query": "^5.85.5",


### PR DESCRIPTION
## Summary of changes

1. Get counts of each navbar section
2. unit tests added
3. Filter sections with 0 results

## Steps to test

1. Confirm number of pokemon in navbar equals the amount in the pagination
2. Confirm no sections with 0 results appear
