### PR TITLE
chore: Set dependabot default to 1 day to match pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 1
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary of changes

1. Set min age for dependabot to suggest at 1 day to match pnpm

## Steps to test

1. Run dependabot
