### PR TITLE
chore: Remove neon branches on branch delete

### DIFF
--- a/.github/workflows/neon-cleanup.yml
+++ b/.github/workflows/neon-cleanup.yml
@@ -1,0 +1,23 @@
+name: Delete Neon Branch
+
+on:
+  delete:
+
+permissions:
+  contents: read
+
+jobs:
+  delete-neon-branch:
+    name: Delete Neon Branch
+    if: |
+      github.event.ref_type == 'branch' &&
+      github.event.ref != 'development' &&
+      github.event.ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon preview branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: preview/${{ github.event.ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary of changes

1. A max of 10 branches are allowed, so on deleting a branch, which happens with PR merge, run a script to kil that branch

## Steps to test

1. Requires merge to test
