### PR TITLE
chore: increase default cooldown days from 1 to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 1
+      default-days: 3
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary of changes

1. Update dependabot cooldown to 3 days

## Steps to test

1.
