### PR TITLE
feat: Add pokemonForms query and related types

### DIFF
--- a/backend/pokedex-graphql/src/context.ts
+++ b/backend/pokedex-graphql/src/context.ts
@@ -25,7 +25,7 @@ export async function createContext(config?: DataSourceConfig): Promise<DataSour
     ...config,
   });
 
-  // Lazy-load index on first request; static cache reuses across warm instances
+  // Lazy-load indexes on first request; static cache reuses across warm instances
   await pokemonAPI.loadPokemonIndex();
 
   return {

--- a/backend/pokedex-graphql/src/datasources/pokemon-api.test.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.test.ts
@@ -1,0 +1,210 @@
+import { InMemoryLRUCache } from "@apollo/utils.keyvaluecache";
+import { HttpResponse, http } from "msw";
+import { server } from "../mocks/server.js";
+import { PokemonAPI } from "./pokemon-api.js";
+
+const api = () => new PokemonAPI({ cache: new InMemoryLRUCache() });
+
+const loaded = async () => {
+  const pokemonAPI = api();
+  await pokemonAPI.loadPokemonIndex();
+  return pokemonAPI;
+};
+
+beforeEach(() => {
+  PokemonAPI.resetIndexes();
+});
+
+describe("loadPokemonIndex", () => {
+  it("indexes species from the species endpoint", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.getPokemonIndex().map(({ name }) => name)).toEqual([
+      "bulbasaur",
+      "ivysaur",
+      "venusaur",
+      "charmander",
+      "charmeleon",
+      "charizard",
+    ]);
+  });
+
+  it("indexes only the alternate forms from the pokemon endpoint", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.getFormsIndex()).toEqual([
+      { id: "10034", name: "charizard-mega-x", number: 10034 },
+      { id: "10186", name: "bulbasaur-gmax", number: 10186 },
+      { id: "10199", name: "pikachu-gmax", number: 10199 },
+    ]);
+  });
+
+  it("keeps no form in the species index", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.getPokemonIndex().every(({ number }) => number < 10000)).toBe(true);
+  });
+
+  it("reports whether it has loaded", async () => {
+    const pokemonAPI = api();
+    expect(pokemonAPI.isIndexLoaded()).toBe(false);
+
+    await pokemonAPI.loadPokemonIndex();
+    expect(pokemonAPI.isIndexLoaded()).toBe(true);
+  });
+
+  it("throws rather than serving an empty index when asked before loading", () => {
+    expect(() => api().getPokemonIndex()).toThrow("Pokemon index not loaded");
+    expect(() => api().getFormsIndex()).toThrow("Pokemon index not loaded");
+  });
+
+  it("fetches each list once when several cold requests arrive together", async () => {
+    let speciesRequests = 0;
+    let pokemonRequests = 0;
+
+    server.use(
+      http.get("https://pokeapi.co/api/v2/pokemon-species", async () => {
+        speciesRequests++;
+        return passthroughList("pokemon-species");
+      }),
+      http.get("https://pokeapi.co/api/v2/pokemon", async () => {
+        pokemonRequests++;
+        return passthroughList("pokemon");
+      }),
+    );
+
+    await Promise.all([
+      api().loadPokemonIndex(),
+      api().loadPokemonIndex(),
+      api().loadPokemonIndex(),
+    ]);
+
+    expect(speciesRequests).toBe(1);
+    expect(pokemonRequests).toBe(1);
+  });
+
+  it("retries after a failed load rather than latching the failure", async () => {
+    server.use(
+      http.get(
+        "https://pokeapi.co/api/v2/pokemon-species",
+        () => new HttpResponse(null, { status: 500 }),
+        { once: true },
+      ),
+    );
+
+    await expect(api().loadPokemonIndex()).rejects.toThrow();
+
+    await expect(api().loadPokemonIndex()).resolves.toBeUndefined();
+  });
+});
+
+describe("searchFormsIndex", () => {
+  it("matches a substring that only ever appears in a form name", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.searchFormsIndex("gmax").map(({ name }) => name)).toEqual([
+      "bulbasaur-gmax",
+      "pikachu-gmax",
+    ]);
+  });
+
+  it("is case insensitive", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.searchFormsIndex("MEGA")).toHaveLength(1);
+  });
+
+  it("does not reach into the species index", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.searchFormsIndex("venusaur")).toEqual([]);
+  });
+});
+
+describe("index immutability", () => {
+  it("hands out the same array each time", async () => {
+    const pokemonAPI = await loaded();
+
+    expect(pokemonAPI.getPokemonIndex()).toBe(pokemonAPI.getPokemonIndex());
+  });
+
+  it("is not reordered by a caller sorting its results", async () => {
+    const pokemonAPI = await loaded();
+    const index = pokemonAPI.getPokemonIndex();
+
+    [...index].sort((a, b) => b.number - a.number);
+
+    expect(index.map(({ number }) => number)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe("getFormsForSpecies", () => {
+  it("returns every variety of the species", async () => {
+    const forms = await api().getFormsForSpecies("1");
+
+    expect(forms.map(({ name }) => name)).toEqual(["bulbasaur", "bulbasaur-gmax"]);
+  });
+
+  it("puts the default first, so the switcher can offer a way back", async () => {
+    const forms = await api().getFormsForSpecies("1");
+
+    expect(forms[0]).toMatchObject({ id: "1", isDefault: true });
+    expect(forms[1]).toMatchObject({ id: "10186", isDefault: false });
+  });
+
+  it("falls back to official artwork for a form with no default sprite", async () => {
+    const forms = await api().getFormsForSpecies("1");
+
+    expect(forms[1].image).toBe(
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/10186.png",
+    );
+  });
+});
+
+describe("getEvolutionForSpecies", () => {
+  it("resolves a chain for a species", async () => {
+    const chain = await api().getEvolutionForSpecies("1");
+
+    expect(chain.chain.name).toBe("bulbasaur");
+  });
+
+  it("is never given a form id by getPokemon's own output", async () => {
+    const form = await api().getPokemon("10186");
+
+    expect(form.speciesId).toBe("1");
+    await expect(api().getEvolutionForSpecies(form.speciesId)).resolves.toBeDefined();
+  });
+
+  it("rejects when handed a form id", async () => {
+    await expect(api().getEvolutionForSpecies("10186")).rejects.toThrow();
+  });
+});
+
+describe("getPokemonByType", () => {
+  it("drops alternate forms so it counts the same population as the other facets", async () => {
+    server.use(
+      http.get("https://pokeapi.co/api/v2/type/:type", () =>
+        HttpResponse.json({
+          pokemon: [
+            { pokemon: { name: "pikachu", url: "https://pokeapi.co/api/v2/pokemon/25/" } },
+            {
+              pokemon: {
+                name: "pikachu-gmax",
+                url: "https://pokeapi.co/api/v2/pokemon/10199/",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    const results = await api().getPokemonByType("electric");
+
+    expect(results.map(({ name }) => name)).toEqual(["pikachu"]);
+  });
+});
+
+async function passthroughList(resource: "pokemon" | "pokemon-species") {
+  const { pokemonList, pokemonSpeciesList } = await import("../mocks/pokemon.js");
+  return HttpResponse.json(resource === "pokemon" ? pokemonList : pokemonSpeciesList);
+}

--- a/backend/pokedex-graphql/src/datasources/pokemon-api.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.ts
@@ -6,6 +6,7 @@ import type {
   EvolutionChain,
   EvolutionNode,
   Pokemon,
+  PokemonForm,
   PokemonPokedex,
   PokemonRegion,
   PokemonType,
@@ -18,6 +19,8 @@ import {
   convertPokemonEntityToPokemon,
   getEvolutionDetail,
   getIdFromUrl,
+  isForm,
+  isSpecies,
   toPokemonIndex,
 } from "../utils/pokemon.js";
 import { convertRegionToRegionDetail } from "../utils/region.js";
@@ -38,34 +41,56 @@ import type {
   TypeResponse,
 } from "./pokemon-api.types.js";
 
+type PokemonIndexes = {
+  species: PokemonIndex[];
+  forms: PokemonIndex[];
+};
+
 export class PokemonAPI extends RESTDataSource {
   baseURL = "https://pokeapi.co/api/v2/";
-  private static pokemonIndex: PokemonIndex[] = [];
-  private static isIndexLoaded = false;
+  private static indexes: PokemonIndexes | null = null;
+  private static indexLoad: Promise<PokemonIndexes> | null = null;
 
-  // Request name/ids of all pokemon for search
   async loadPokemonIndex(): Promise<void> {
-    if (PokemonAPI.isIndexLoaded) return;
+    if (PokemonAPI.indexes) return;
+
+    if (!PokemonAPI.indexLoad) {
+      PokemonAPI.indexLoad = this.fetchIndexes();
+    }
+
+    const load = PokemonAPI.indexLoad;
 
     try {
-      const response = await this.get<PokemonListResponse>("pokemon?limit=1500");
-      const entries = response.results;
-
-      PokemonAPI.pokemonIndex = entries
-        .map(toPokemonIndex)
-        .sort((a: PokemonIndex, b: PokemonIndex) => a.number - b.number);
-
-      PokemonAPI.isIndexLoaded = true;
-      logger.info(`Loaded ${PokemonAPI.pokemonIndex.length} Pokémon into index`);
+      PokemonAPI.indexes = await load;
     } catch (error) {
+      if (PokemonAPI.indexLoad === load) PokemonAPI.indexLoad = null;
       logger.error("Failed to load Pokémon index:", error);
       throw error;
     }
   }
 
+  private async fetchIndexes(): Promise<PokemonIndexes> {
+    const [speciesResponse, pokemonResponse] = await Promise.all([
+      this.get<PokemonListResponse>("pokemon-species?limit=1500"),
+      this.get<PokemonListResponse>("pokemon?limit=1500"),
+    ]);
+
+    const species = sortByNumber(speciesResponse.results.map(toPokemonIndex));
+    const forms = sortByNumber(pokemonResponse.results.map(toPokemonIndex).filter(isForm));
+
+    logger.info(`Loaded ${species.length} Pokémon and ${forms.length} forms into index`);
+
+    return { species, forms };
+  }
+
   // Check if index is loaded
   isIndexLoaded(): boolean {
-    return PokemonAPI.isIndexLoaded;
+    return PokemonAPI.indexes !== null;
+  }
+
+  static resetIndexes(): void {
+    PokemonAPI.indexes = null;
+    PokemonAPI.indexLoad = null;
   }
 
   getAbility(id: string): Promise<Ability> {
@@ -104,17 +129,19 @@ export class PokemonAPI extends RESTDataSource {
 
     return {
       id: pokemon.id,
-      name: pokemon.name,
+      // The species' name, not the default form's: a chain is a chain of
+      // species, and the two differ wherever the base form carries a suffix —
+      // a stage reading "Aegislash Shield" would name a form the chain has no
+      // other member of.
+      name: link.species.name,
       image: pokemon.image,
       ...getEvolutionDetail(link.evolution_details),
       evolvesTo,
     };
   }
 
-  // Resolve a Pokemon's full evolution chain: pokemon -> species ->
-  // evolution chain -> a tree of nodes with links back to each Pokemon.
-  async getEvolutionForPokemon(id: string): Promise<EvolutionChain> {
-    const species = await this.getPokemonSpecies(id);
+  async getEvolutionForSpecies(speciesId: string): Promise<EvolutionChain> {
+    const species = await this.getPokemonSpecies(speciesId);
     const chainResponse = await this.get<EvolutionChainResponse>(species.evolution_chain.url);
 
     return {
@@ -123,22 +150,54 @@ export class PokemonAPI extends RESTDataSource {
     };
   }
 
-  // The whole index, already in dex order. Backs an unfiltered pokemonFilter.
-  getPokemonIndex(): PokemonIndex[] {
-    if (!PokemonAPI.isIndexLoaded) {
+  async getFormsForSpecies(speciesId: string): Promise<PokemonForm[]> {
+    const species = await this.getPokemonSpecies(speciesId);
+
+    const forms = await Promise.all(
+      species.varieties.map(async (variety) => {
+        const pokemon = await this.getPokemon(getIdFromUrl(variety.pokemon.url));
+
+        return {
+          id: pokemon.id,
+          name: pokemon.name,
+          image: pokemon.image,
+          isDefault: variety.is_default,
+        };
+      }),
+    );
+
+    return forms.sort((a, b) => Number(b.isDefault) - Number(a.isDefault));
+  }
+
+  private static requireIndexes(): PokemonIndexes {
+    if (!PokemonAPI.indexes) {
       throw new Error("Pokemon index not loaded. Call loadPokemonIndex() first.");
     }
 
-    return PokemonAPI.pokemonIndex;
+    return PokemonAPI.indexes;
+  }
+
+  getPokemonIndex(): PokemonIndex[] {
+    return PokemonAPI.requireIndexes().species;
+  }
+
+  getFormsIndex(): PokemonIndex[] {
+    return PokemonAPI.requireIndexes().forms;
+  }
+
+  private static matchName(entries: PokemonIndex[], query: string): PokemonIndex[] {
+    const lowerQuery = query.toLowerCase();
+
+    return entries.filter((pokemon) => pokemon.name.toLowerCase().includes(lowerQuery));
   }
 
   // Every name match, unpaginated, so it can be composed with other facets.
   searchPokemonIndex(query: string): PokemonIndex[] {
-    const lowerQuery = query.toLowerCase();
+    return PokemonAPI.matchName(this.getPokemonIndex(), query);
+  }
 
-    return this.getPokemonIndex().filter((pokemon) =>
-      pokemon.name.toLowerCase().includes(lowerQuery),
-    );
+  searchFormsIndex(query: string): PokemonIndex[] {
+    return PokemonAPI.matchName(this.getFormsIndex(), query);
   }
 
   getPokemonByPokedex(pokedex: string): Promise<PokemonIndex[]> {
@@ -222,7 +281,9 @@ export class PokemonAPI extends RESTDataSource {
     logger.info(`Fetching Pokemon of type: ${type}`);
     return this.get<TypeResponse>(`type/${type}`)
       .then((data) => {
-        const results = data.pokemon.map((result) => toPokemonIndex(result.pokemon));
+        const results = data.pokemon
+          .map((result) => toPokemonIndex(result.pokemon))
+          .filter(isSpecies);
         return sortByNumber(results);
       })
       .catch((error) => {

--- a/backend/pokedex-graphql/src/datasources/pokemon-api.types.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.types.ts
@@ -154,6 +154,11 @@ export type PokemonResponse = {
   results: PokemonEntity[];
 };
 
+export type PokemonSpeciesVariety = {
+  is_default: boolean;
+  pokemon: NamedAPIResource;
+};
+
 // Species-related types (used to reach the evolution chain from a Pokemon)
 export type PokemonSpecies = {
   id: number;
@@ -161,6 +166,7 @@ export type PokemonSpecies = {
   evolution_chain: {
     url: string;
   };
+  varieties: PokemonSpeciesVariety[];
 };
 
 // Evolution-related types

--- a/backend/pokedex-graphql/src/mocks/handlers.ts
+++ b/backend/pokedex-graphql/src/mocks/handlers.ts
@@ -1,18 +1,29 @@
 import { URL } from "node:url";
 import { HttpResponse, http } from "msw";
+import { FORM_ID_THRESHOLD } from "../utils/pokemon.js";
 import {
+  charizardMegaXEntity,
   evolutionChain,
+  pikachuGmaxEntity,
   pokedex,
   pokedexListResponse,
   pokemonAbility,
   pokemonEntity,
+  pokemonFormEntity,
   pokemonList,
   pokemonSpecies,
+  pokemonSpeciesList,
   region,
   regionListResponse,
   typeListResponse,
   typeResponse,
 } from "./pokemon.js";
+
+const pokemonById: Record<string, unknown> = {
+  "10034": charizardMegaXEntity,
+  "10186": pokemonFormEntity,
+  "10199": pikachuGmaxEntity,
+};
 
 export const handlers = [
   // Pokemon list endpoint - used by loadPokemonIndex()
@@ -29,19 +40,25 @@ export const handlers = [
     return HttpResponse.json(pokemonList);
   }),
 
+  http.get("https://pokeapi.co/api/v2/pokemon-species", () => {
+    return HttpResponse.json(pokemonSpeciesList);
+  }),
+
   // Pokemon detail endpoint - used by getPokemon()
-  http.get("https://pokeapi.co/api/v2/pokemon/:id", () => {
-    // Return mock data for any Pokemon ID
-    return HttpResponse.json(pokemonEntity);
+  http.get("https://pokeapi.co/api/v2/pokemon/:id", ({ params }) => {
+    return HttpResponse.json(pokemonById[String(params.id)] ?? pokemonEntity);
   }),
 
   // Pokemon species endpoint - used by getPokemonSpecies()
-  http.get("https://pokeapi.co/api/v2/pokemon-species/:id", () => {
-    // Return mock data for any species ID
+  http.get("https://pokeapi.co/api/v2/pokemon-species/:id", ({ params }) => {
+    if (Number(params.id) >= FORM_ID_THRESHOLD) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
     return HttpResponse.json(pokemonSpecies);
   }),
 
-  // Evolution chain endpoint - used by getEvolutionForPokemon()
+  // Evolution chain endpoint - used by getEvolutionForSpecies()
   http.get("https://pokeapi.co/api/v2/evolution-chain/:id", () => {
     // Return mock data for any evolution chain ID
     return HttpResponse.json(evolutionChain);

--- a/backend/pokedex-graphql/src/mocks/pokemon.ts
+++ b/backend/pokedex-graphql/src/mocks/pokemon.ts
@@ -37,6 +37,32 @@ export const pokemonList: {
       name: "charizard",
       url: "https://pokeapi.co/api/v2/pokemon/6/",
     },
+    {
+      name: "charizard-mega-x",
+      url: "https://pokeapi.co/api/v2/pokemon/10034/",
+    },
+    {
+      name: "bulbasaur-gmax",
+      url: "https://pokeapi.co/api/v2/pokemon/10186/",
+    },
+    {
+      name: "pikachu-gmax",
+      url: "https://pokeapi.co/api/v2/pokemon/10199/",
+    },
+  ],
+};
+
+export const pokemonSpeciesList: typeof pokemonList = {
+  count: 1025,
+  next: "https://pokeapi.co/api/v2/pokemon-species?offset=20&limit=20",
+  previous: null,
+  results: [
+    { name: "bulbasaur", url: "https://pokeapi.co/api/v2/pokemon-species/1/" },
+    { name: "ivysaur", url: "https://pokeapi.co/api/v2/pokemon-species/2/" },
+    { name: "venusaur", url: "https://pokeapi.co/api/v2/pokemon-species/3/" },
+    { name: "charmander", url: "https://pokeapi.co/api/v2/pokemon-species/4/" },
+    { name: "charmeleon", url: "https://pokeapi.co/api/v2/pokemon-species/5/" },
+    { name: "charizard", url: "https://pokeapi.co/api/v2/pokemon-species/6/" },
   ],
 };
 
@@ -384,7 +410,50 @@ export const pokemonSpecies: PokemonSpecies = {
   evolution_chain: {
     url: "https://pokeapi.co/api/v2/evolution-chain/1/",
   },
+  varieties: [
+    {
+      is_default: true,
+      pokemon: { name: "bulbasaur", url: "https://pokeapi.co/api/v2/pokemon/1/" },
+    },
+    {
+      is_default: false,
+      pokemon: { name: "bulbasaur-gmax", url: "https://pokeapi.co/api/v2/pokemon/10186/" },
+    },
+  ],
 };
+
+const formEntity = (id: number, name: string, speciesId: number): typeof pokemonEntity => ({
+  ...pokemonEntity,
+  id,
+  name,
+  is_default: false,
+  species: {
+    name: name.split("-")[0],
+    url: `https://pokeapi.co/api/v2/pokemon-species/${speciesId}/`,
+  },
+});
+
+export const pokemonFormEntity: typeof pokemonEntity = {
+  ...formEntity(10186, "bulbasaur-gmax", 1),
+  sprites: {
+    ...pokemonEntity.sprites,
+    back_default: null,
+    back_shiny: null,
+    front_default: null,
+    front_shiny: null,
+    other: {
+      ...pokemonEntity.sprites.other,
+      "official-artwork": {
+        front_default:
+          "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/10186.png",
+        front_shiny: null,
+      },
+    },
+  },
+};
+
+export const charizardMegaXEntity = formEntity(10034, "charizard-mega-x", 6);
+export const pikachuGmaxEntity = formEntity(10199, "pikachu-gmax", 25);
 
 export const evolutionChain: EvolutionChainResponse = {
   id: 1,

--- a/backend/pokedex-graphql/src/resolvers.test.ts
+++ b/backend/pokedex-graphql/src/resolvers.test.ts
@@ -1,0 +1,183 @@
+import { InMemoryLRUCache } from "@apollo/utils.keyvaluecache";
+import { createSchema, createYoga } from "graphql-yoga";
+import { HttpResponse, http } from "msw";
+import { createContext, type DataSourceContext } from "./context.js";
+import { PokemonAPI } from "./datasources/pokemon-api.js";
+import { pokemonEntity } from "./mocks/pokemon.js";
+import { server } from "./mocks/server.js";
+import { resolvers } from "./resolvers.js";
+import { typeDefs } from "./schema.generated.js";
+
+const yoga = createYoga({
+  schema: createSchema<DataSourceContext>({ typeDefs, resolvers }),
+  context: () => createContext({ cache: new InMemoryLRUCache() }),
+});
+
+const run = async (query: string, variables?: Record<string, unknown>) => {
+  const response = await yoga.fetch("http://pokedex.test/graphql", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const { data, errors } = (await response.json()) as {
+    data?: Record<string, unknown>;
+    errors?: unknown[];
+  };
+
+  expect(errors).toBeUndefined();
+  expect(data).toBeDefined();
+
+  return data as Record<string, unknown>;
+};
+
+beforeEach(() => {
+  PokemonAPI.resetIndexes();
+});
+
+describe("pokemonForms", () => {
+  it("browses every form when given no query", async () => {
+    const data = await run(`{ pokemonForms { total pokemon { id } } }`);
+
+    expect(data.pokemonForms).toMatchObject({ total: 3 });
+  });
+
+  it("narrows to a substring of the form name", async () => {
+    const data = await run(`{ pokemonForms(query: "gmax") { total } }`);
+
+    expect(data.pokemonForms).toMatchObject({ total: 2 });
+  });
+
+  it("counts forms, not species", async () => {
+    const data = await run(`{ pokemonForms { total } }`);
+    const all = await run(`{ pokemonFilter(filter: {}) { total } }`);
+
+    expect(data.pokemonForms).toMatchObject({ total: 3 });
+    expect(all?.pokemonFilter).toMatchObject({ total: 6 });
+  });
+
+  it("paginates and echoes the offset back", async () => {
+    const data = await run(`{ pokemonForms(limit: 2, offset: 1) { total offset pokemon { id } } }`);
+
+    expect(data.pokemonForms).toMatchObject({ total: 3, offset: 1 });
+    expect((data.pokemonForms as { pokemon: unknown[] }).pokemon).toHaveLength(2);
+  });
+
+  it("orders by id by default and alphabetically when asked", async () => {
+    const names = async (sort: string) => {
+      const data = await run(`{ pokemonForms(sort: ${sort}) { pokemon { name } } }`);
+      return (data.pokemonForms as { pokemon: { name: string }[] }).pokemon.map((p) => p.name);
+    };
+
+    expect(await names("ID_ASC")).toEqual(["charizard-mega-x", "bulbasaur-gmax", "pikachu-gmax"]);
+    expect(await names("NAME_ASC")).toEqual(["bulbasaur-gmax", "charizard-mega-x", "pikachu-gmax"]);
+  });
+});
+
+describe("pokemonFilter", () => {
+  it("browses the species index, not the pokemon list, when the filter is empty", async () => {
+    const data = await run(`{ pokemonFilter(filter: {}) { total } }`);
+
+    expect(data.pokemonFilter).toMatchObject({ total: 6 });
+  });
+
+  it("does not match a form name", async () => {
+    const data = await run(`{ pokemonFilter(filter: { query: "gmax" }) { total } }`);
+
+    expect(data.pokemonFilter).toMatchObject({ total: 0 });
+  });
+});
+
+describe("Pokemon.forms", () => {
+  it("lists every variety of the species, default first", async () => {
+    const data = await run(`{ pokemon(id: "1") { forms { id name isDefault } } }`);
+
+    expect(data.pokemon).toEqual({
+      forms: [
+        { id: "1", name: "bulbasaur", isDefault: true },
+        { id: "10186", name: "bulbasaur-gmax", isDefault: false },
+      ],
+    });
+  });
+
+  it("resolves the same list from a form as from its species", async () => {
+    const fromSpecies = await run(`{ pokemon(id: "1") { forms { id } } }`);
+    const fromForm = await run(`{ pokemon(id: "10186") { forms { id } } }`);
+
+    expect(fromForm).toEqual(fromSpecies);
+  });
+
+  it("degrades to null instead of nulling the whole Pokemon", async () => {
+    server.use(
+      http.get(
+        "https://pokeapi.co/api/v2/pokemon-species/:id",
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    const data = await run(`{ pokemon(id: "1") { name forms { id } } }`);
+
+    expect(data.pokemon).toEqual({ name: "bulbasaur", forms: null });
+  });
+});
+
+describe("Pokemon.speciesId", () => {
+  it("equals the id for a default Pokemon", async () => {
+    const data = await run(`{ pokemon(id: "1") { id speciesId } }`);
+
+    expect(data.pokemon).toEqual({ id: "1", speciesId: "1" });
+  });
+
+  it("points at the base species for a form", async () => {
+    const data = await run(`{ pokemon(id: "10186") { id speciesId } }`);
+
+    expect(data.pokemon).toEqual({ id: "10186", speciesId: "1" });
+  });
+});
+
+describe("Pokemon.speciesName", () => {
+  it("names the species rather than the Pokemon", async () => {
+    const data = await run(`{ pokemon(id: "10186") { name speciesName } }`);
+
+    expect(data.pokemon).toEqual({ name: "bulbasaur-gmax", speciesName: "bulbasaur" });
+  });
+
+  it("is the species even when the default form's name carries a suffix", async () => {
+    server.use(
+      http.get("https://pokeapi.co/api/v2/pokemon/:id", () =>
+        HttpResponse.json({
+          ...pokemonEntity,
+          id: 681,
+          name: "aegislash-shield",
+          species: { name: "aegislash", url: "https://pokeapi.co/api/v2/pokemon-species/681/" },
+        }),
+      ),
+    );
+
+    const data = await run(`{ pokemon(id: "681") { name speciesName } }`);
+
+    expect(data.pokemon).toEqual({ name: "aegislash-shield", speciesName: "aegislash" });
+  });
+});
+
+describe("Pokemon.evolution", () => {
+  it("resolves on a form page rather than 404ing on its id", async () => {
+    const data = await run(`{ pokemon(id: "10186") { evolution { chain { name } } } }`);
+
+    expect(data.pokemon).toEqual({ evolution: { chain: { name: "bulbasaur" } } });
+  });
+
+  it("names each stage by its species rather than its default form", async () => {
+    // A chain is a chain of species, so a stage whose base form is spelled
+    // `aegislash-shield` upstream still reads "aegislash" here.
+    server.use(
+      http.get("https://pokeapi.co/api/v2/pokemon/:id", () =>
+        HttpResponse.json({ ...pokemonEntity, id: 681, name: "aegislash-shield" }),
+      ),
+    );
+
+    const data = await run(`{ pokemon(id: "1") { evolution { chain { name } } } }`);
+
+    expect(data.pokemon).toEqual({ evolution: { chain: { name: "bulbasaur" } } });
+  });
+});

--- a/backend/pokedex-graphql/src/resolvers.ts
+++ b/backend/pokedex-graphql/src/resolvers.ts
@@ -161,6 +161,35 @@ export const resolvers: Resolvers = {
         throw error;
       }
     },
+    pokemonForms: async (
+      _,
+      { query, limit = 20, offset = 0, sort = PokemonSort.IdAsc },
+      { dataSources },
+    ) => {
+      logger.info(`Resolving pokemonForms query: "${query ?? ""}" with limit: ${limit}`);
+      try {
+        const { pokemonAPI } = dataSources;
+        const results = sortResults(
+          query ? pokemonAPI.searchFormsIndex(query) : pokemonAPI.getFormsIndex(),
+          sort,
+        );
+        const total = results.length;
+        const limitedResults = getPaginatedResults(results, limit, offset);
+
+        const pokemon = await Promise.all(
+          limitedResults.map(({ id }) => pokemonAPI.getPokemon(id)),
+        );
+        logger.info(`pokemonForms resolved ${pokemon.length} of ${total} forms`);
+        return {
+          total,
+          offset,
+          pokemon,
+        };
+      } catch (error) {
+        logger.error(`Error resolving pokemonForms "${query}":`, error);
+        throw error;
+      }
+    },
     pokemonByType: async (
       _,
       { type, limit = 20, offset = 0, sort = PokemonSort.IdAsc },
@@ -347,16 +376,25 @@ export const resolvers: Resolvers = {
         throw error;
       }
     },
-    evolution: async ({ id }, _, { dataSources }) => {
-      logger.info(`Resolving evolution chain for Pokemon ${id}`);
+    evolution: async ({ id, speciesId }, _, { dataSources }) => {
+      logger.info(`Resolving evolution chain for Pokemon ${id} (species ${speciesId})`);
       try {
-        const result = await dataSources.pokemonAPI.getEvolutionForPokemon(id);
+        const result = await dataSources.pokemonAPI.getEvolutionForSpecies(speciesId);
         logger.info(`Evolution chain for Pokemon ${id} resolved successfully`);
         return result;
       } catch (error) {
         // Evolution data is supplementary — a failure here should not break
         // the whole Pokemon query, so log it and omit the section.
         logger.error(`Error resolving evolution for Pokemon ${id}:`, error);
+        return null;
+      }
+    },
+    forms: async ({ id, speciesId }, _, { dataSources }) => {
+      logger.info(`Resolving forms for Pokemon ${id} (species ${speciesId})`);
+      try {
+        return await dataSources.pokemonAPI.getFormsForSpecies(speciesId);
+      } catch (error) {
+        logger.error(`Error resolving forms for Pokemon ${id}:`, error);
         return null;
       }
     },

--- a/backend/pokedex-graphql/src/schema.generated.ts
+++ b/backend/pokedex-graphql/src/schema.generated.ts
@@ -3,6 +3,7 @@ export const typeDefs = /* GraphQL */ `
 type Query {
   pokemon(id: ID!): Pokemon
   pokemonSearch(query: String!, limit: Int, offset: Int, sort: PokemonSort = ID_ASC): PokemonList
+  pokemonForms(query: String, limit: Int, offset: Int, sort: PokemonSort = ID_ASC): PokemonList
   pokemonByType(type: String, limit: Int, offset: Int, sort: PokemonSort = ID_ASC): PokemonList
   pokemonByPokedex(
     pokedex: String
@@ -81,6 +82,8 @@ type PokemonList {
 
 type Pokemon {
   id: ID!
+  speciesId: ID!
+  speciesName: String!
   name: String!
   type: [String!]!
   image: String!
@@ -88,6 +91,14 @@ type Pokemon {
   abilitiesLite: [AbilityLite!]!
   abilities: [Ability!]
   evolution: EvolutionChain
+  forms: [PokemonForm!]
+}
+
+type PokemonForm {
+  id: ID!
+  name: String!
+  image: String!
+  isDefault: Boolean!
 }
 
 type EvolutionChain {

--- a/backend/pokedex-graphql/src/schema.graphql
+++ b/backend/pokedex-graphql/src/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
   pokemon(id: ID!): Pokemon
   pokemonSearch(query: String!, limit: Int, offset: Int, sort: PokemonSort = ID_ASC): PokemonList
+  pokemonForms(query: String, limit: Int, offset: Int, sort: PokemonSort = ID_ASC): PokemonList
   pokemonByType(type: String, limit: Int, offset: Int, sort: PokemonSort = ID_ASC): PokemonList
   pokemonByPokedex(
     pokedex: String
@@ -79,6 +80,8 @@ type PokemonList {
 
 type Pokemon {
   id: ID!
+  speciesId: ID!
+  speciesName: String!
   name: String!
   type: [String!]!
   image: String!
@@ -86,6 +89,14 @@ type Pokemon {
   abilitiesLite: [AbilityLite!]!
   abilities: [Ability!]
   evolution: EvolutionChain
+  forms: [PokemonForm!]
+}
+
+type PokemonForm {
+  id: ID!
+  name: String!
+  image: String!
+  isDefault: Boolean!
 }
 
 type EvolutionChain {

--- a/backend/pokedex-graphql/src/types.ts
+++ b/backend/pokedex-graphql/src/types.ts
@@ -63,9 +63,12 @@ export type Pokemon = {
   abilities?: Maybe<Array<Ability>>;
   abilitiesLite: Array<AbilityLite>;
   evolution?: Maybe<EvolutionChain>;
+  forms?: Maybe<Array<PokemonForm>>;
   id: Scalars['ID']['output'];
   image: Scalars['String']['output'];
   name: Scalars['String']['output'];
+  speciesId: Scalars['ID']['output'];
+  speciesName: Scalars['String']['output'];
   stats: Stats;
   type: Array<Scalars['String']['output']>;
 };
@@ -90,6 +93,14 @@ export type PokemonFilter = {
   query?: InputMaybe<Scalars['String']['input']>;
   regions?: InputMaybe<Array<Scalars['String']['input']>>;
   types?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type PokemonForm = {
+  __typename?: 'PokemonForm';
+  id: Scalars['ID']['output'];
+  image: Scalars['String']['output'];
+  isDefault: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
 };
 
 /** Results are ordered by the query's `sort`, national dex number by default. */
@@ -138,6 +149,7 @@ export type Query = {
   pokemonByRegion?: Maybe<PokemonList>;
   pokemonByType?: Maybe<PokemonList>;
   pokemonFilter?: Maybe<PokemonList>;
+  pokemonForms?: Maybe<PokemonList>;
   pokemonSearch?: Maybe<PokemonList>;
   region?: Maybe<RegionDetail>;
   regions: Array<PokemonRegion>;
@@ -184,6 +196,14 @@ export type QueryPokemonFilterArgs = {
   filter: PokemonFilter;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<PokemonSort>;
+};
+
+
+export type QueryPokemonFormsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
   sort?: InputMaybe<PokemonSort>;
 };
 
@@ -337,6 +357,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Pokemon: ResolverTypeWrapper<Pokemon>;
   PokemonFilter: PokemonFilter;
+  PokemonForm: ResolverTypeWrapper<PokemonForm>;
   PokemonList: ResolverTypeWrapper<PokemonList>;
   PokemonPokedex: ResolverTypeWrapper<PokemonPokedex>;
   PokemonRegion: ResolverTypeWrapper<PokemonRegion>;
@@ -362,6 +383,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int']['output'];
   Pokemon: Pokemon;
   PokemonFilter: PokemonFilter;
+  PokemonForm: PokemonForm;
   PokemonList: PokemonList;
   PokemonPokedex: PokemonPokedex;
   PokemonRegion: PokemonRegion;
@@ -410,11 +432,21 @@ export type PokemonResolvers<ContextType = DataSourceContext, ParentType extends
   abilities?: Resolver<Maybe<Array<ResolversTypes['Ability']>>, ParentType, ContextType>;
   abilitiesLite?: Resolver<Array<ResolversTypes['AbilityLite']>, ParentType, ContextType>;
   evolution?: Resolver<Maybe<ResolversTypes['EvolutionChain']>, ParentType, ContextType>;
+  forms?: Resolver<Maybe<Array<ResolversTypes['PokemonForm']>>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  speciesId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  speciesName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   stats?: Resolver<ResolversTypes['Stats'], ParentType, ContextType>;
   type?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PokemonFormResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonForm'] = ResolversParentTypes['PokemonForm']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  isDefault?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 };
 
 export type PokemonListResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonList'] = ResolversParentTypes['PokemonList']> = {
@@ -446,6 +478,7 @@ export type QueryResolvers<ContextType = DataSourceContext, ParentType extends R
   pokemonByRegion?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, RequireFields<QueryPokemonByRegionArgs, 'sort'>>;
   pokemonByType?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, RequireFields<QueryPokemonByTypeArgs, 'sort'>>;
   pokemonFilter?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, RequireFields<QueryPokemonFilterArgs, 'filter' | 'sort'>>;
+  pokemonForms?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, RequireFields<QueryPokemonFormsArgs, 'sort'>>;
   pokemonSearch?: Resolver<Maybe<ResolversTypes['PokemonList']>, ParentType, ContextType, RequireFields<QueryPokemonSearchArgs, 'query' | 'sort'>>;
   region?: Resolver<Maybe<ResolversTypes['RegionDetail']>, ParentType, ContextType, RequireFields<QueryRegionArgs, 'name'>>;
   regions?: Resolver<Array<ResolversTypes['PokemonRegion']>, ParentType, ContextType>;
@@ -499,6 +532,7 @@ export type Resolvers<ContextType = DataSourceContext> = {
   EvolutionChain?: EvolutionChainResolvers<ContextType>;
   EvolutionNode?: EvolutionNodeResolvers<ContextType>;
   Pokemon?: PokemonResolvers<ContextType>;
+  PokemonForm?: PokemonFormResolvers<ContextType>;
   PokemonList?: PokemonListResolvers<ContextType>;
   PokemonPokedex?: PokemonPokedexResolvers<ContextType>;
   PokemonRegion?: PokemonRegionResolvers<ContextType>;

--- a/backend/pokedex-graphql/src/utils/pokemon.test.ts
+++ b/backend/pokedex-graphql/src/utils/pokemon.test.ts
@@ -599,6 +599,10 @@ describe("convertPokemonEntityToPokemon", () => {
     const mockPokemonEntity: PokemonEntity = {
       id: 1,
       name: "bulbasaur",
+      species: {
+        name: "bulbasaur",
+        url: "https://pokeapi.co/api/v2/pokemon-species/1/",
+      },
       abilities: [
         {
           ability: {
@@ -696,6 +700,8 @@ describe("convertPokemonEntityToPokemon", () => {
 
     expect(result).toEqual({
       id: "1",
+      speciesId: "1",
+      speciesName: "bulbasaur",
       name: "bulbasaur",
       type: ["grass", "poison"],
       image: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png",
@@ -730,6 +736,10 @@ describe("convertPokemonEntityToPokemon", () => {
     const mockPokemonEntity: PokemonEntity = {
       id: 999,
       name: "test-pokemon",
+      species: {
+        name: "test-pokemon",
+        url: "https://pokeapi.co/api/v2/pokemon-species/999/",
+      },
       abilities: [],
       types: [],
       stats: [],
@@ -763,6 +773,8 @@ describe("convertPokemonEntityToPokemon", () => {
 
     expect(result).toEqual({
       id: "999",
+      speciesId: "999",
+      speciesName: "test-pokemon",
       name: "test-pokemon",
       type: [],
       image: "https://dummyimage.com/96x96/f0f0f0/666666.png&text=test-pokemon",
@@ -782,6 +794,10 @@ describe("convertPokemonEntityToPokemon", () => {
     const mockPokemonEntity: PokemonEntity = {
       id: 25,
       name: "pikachu",
+      species: {
+        name: "pikachu",
+        url: "https://pokeapi.co/api/v2/pokemon-species/25/",
+      },
       abilities: [],
       types: [],
       stats: [],

--- a/backend/pokedex-graphql/src/utils/pokemon.ts
+++ b/backend/pokedex-graphql/src/utils/pokemon.ts
@@ -8,6 +8,12 @@ import type {
 } from "../datasources/pokemon-api.types.js";
 import type { AbilityLite, Pokemon, Stats } from "../types.js";
 
+export const FORM_ID_THRESHOLD = 10000;
+
+export const isForm = (entry: PokemonIndex): boolean => entry.number >= FORM_ID_THRESHOLD;
+
+export const isSpecies = (entry: PokemonIndex): boolean => !isForm(entry);
+
 export const getIdFromUrl = (url: string): string => {
   return url.split("/").filter(Boolean).pop() ?? "";
 };
@@ -121,6 +127,8 @@ export const convertAbilityLiteToAbility = (data: PokemonAbility, abilityLite: A
 export const convertPokemonEntityToPokemon = (pokemon: PokemonEntity): Pokemon => {
   return {
     id: pokemon.id.toString(),
+    speciesId: getIdFromUrl(pokemon.species.url),
+    speciesName: pokemon.species.name,
     name: pokemon.name,
     type: getPokemonTypes(pokemon),
     image: getPokemonDefaultImageUrl(pokemon),

--- a/backend/pokedex-graphql/src/vitest.setup.ts
+++ b/backend/pokedex-graphql/src/vitest.setup.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll } from "vitest";
 import { server } from "./mocks/server";
 
-beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 afterEach(() => server.resetHandlers());
 

--- a/backend/pokedex-graphql/vitest.config.ts
+++ b/backend/pokedex-graphql/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    setupFiles: ["./src/vitest.setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],

--- a/frontend/app/components/PokemonCard/PokemonCard.test.tsx
+++ b/frontend/app/components/PokemonCard/PokemonCard.test.tsx
@@ -34,6 +34,8 @@ vi.mock("next/image", () => ({
 describe("PokemonCard", () => {
   const mockPokemon: Pokemon = {
     id: "1",
+    speciesId: "1",
+    speciesName: "bulbasaur",
     name: "bulbasaur",
     image: "https://example.com/bulbasaur.jpg",
     type: ["grass", "poison"],
@@ -79,6 +81,22 @@ describe("PokemonCard", () => {
     const nameLink = screen.getByText("Bulbasaur");
     expect(nameLink).toBeInTheDocument();
     expect(nameLink.closest("a")).toHaveAttribute("href", "/pokemon/1");
+  });
+
+  describe("a card for an alternate form", () => {
+    const gmax = { ...mockPokemon, id: "10186", speciesId: "1", name: "bulbasaur-gmax" };
+
+    it("links to the form nested under its species", () => {
+      const { container } = render(<PokemonCard pokemon={gmax} />);
+
+      expect(container.querySelector("a")).toHaveAttribute("href", "/pokemon/1/forms/10186");
+    });
+
+    it("shows the species' dex number rather than the form's id", () => {
+      render(<PokemonCard pokemon={gmax} />);
+
+      expect(screen.getByText("#001")).toBeInTheDocument();
+    });
   });
 
   it("displays all Pokemon types", () => {
@@ -131,17 +149,19 @@ describe("PokemonCard", () => {
   it("handles Pokemon with special characters in name", () => {
     const specialNamePokemon: Pokemon = {
       ...mockPokemon,
+      speciesName: "mr-mime",
       name: "mr-mime",
     };
 
     render(<PokemonCard pokemon={specialNamePokemon} />);
 
-    expect(screen.getByText("Mr-mime")).toBeInTheDocument();
+    expect(screen.getByText("Mr Mime")).toBeInTheDocument();
   });
 
   it("handles Pokemon with uppercase name", () => {
     const uppercaseNamePokemon: Pokemon = {
       ...mockPokemon,
+      speciesName: "CHARIZARD",
       name: "CHARIZARD",
     };
 

--- a/frontend/app/components/PokemonCard/PokemonCard.tsx
+++ b/frontend/app/components/PokemonCard/PokemonCard.tsx
@@ -6,9 +6,11 @@ import Link from "next/link";
 import { type FunctionComponent, useState } from "react";
 import PokeballMark from "@/components/PokeballMark";
 import PokemonTypePill from "@/components/PokemonTypePill";
+import { formatPokemonName } from "@/lib/formNames";
+import { buildPokemonPath } from "@/lib/pokemonUrls";
 import type { Pokemon } from "@/types/graphql";
 import css from "./PokemonCard.module.css";
-import { formatPokemonName, getPokemonTypeClass, getPrimaryType } from "./PokemonCard.utils";
+import { getPokemonTypeClass, getPrimaryType } from "./PokemonCard.utils";
 
 interface PokemonCardProps {
   pokemon: Pokemon;
@@ -20,14 +22,14 @@ interface PokemonCardProps {
 export const PokemonCard: FunctionComponent<PokemonCardProps> = ({ pokemon, href }) => {
   const primaryType = getPrimaryType(pokemon.type);
   const typeClass = getPokemonTypeClass(primaryType);
-  const formattedName = formatPokemonName(pokemon.name);
-  const dexNumber = `#${String(pokemon.id).padStart(3, "0")}`;
+  const formattedName = formatPokemonName(pokemon);
+  const dexNumber = `#${String(pokemon.speciesId).padStart(3, "0")}`;
   const [imageLoaded, setImageLoaded] = useState(false);
 
   // Absolute by default: the card also renders from nested routes like
   // /region/kanto, where a relative href would resolve under the current path
   return (
-    <Link href={href ?? `/pokemon/${pokemon.id}`}>
+    <Link href={href ?? buildPokemonPath(pokemon.speciesId, pokemon.id)}>
       <div
         className={`${css.pokemonCard} ${css[typeClass as keyof typeof css]}`}
         data-testid="pokemon-card"

--- a/frontend/app/components/PokemonCard/PokemonCard.util.test.ts
+++ b/frontend/app/components/PokemonCard/PokemonCard.util.test.ts
@@ -1,45 +1,6 @@
-import { formatPokemonName, getPokemonTypeClass, getPrimaryType } from "./PokemonCard.utils";
+import { getPokemonTypeClass, getPrimaryType } from "./PokemonCard.utils";
 
 describe("PokemonCard Utils", () => {
-  describe("formatPokemonName", () => {
-    it("capitalizes first letter of lowercase name", () => {
-      expect(formatPokemonName("bulbasaur")).toBe("Bulbasaur");
-    });
-
-    it("handles already capitalized name", () => {
-      expect(formatPokemonName("Bulbasaur")).toBe("Bulbasaur");
-    });
-
-    it("handles all uppercase name", () => {
-      expect(formatPokemonName("CHARIZARD")).toBe("CHARIZARD");
-    });
-
-    it("handles name with hyphens", () => {
-      expect(formatPokemonName("mr-mime")).toBe("Mr-mime");
-    });
-
-    it("handles single character name", () => {
-      expect(formatPokemonName("a")).toBe("A");
-    });
-
-    it("handles empty string", () => {
-      expect(formatPokemonName("")).toBe("");
-    });
-
-    it("handles name with numbers", () => {
-      expect(formatPokemonName("pikachu123")).toBe("Pikachu123");
-    });
-
-    it("maintains function purity", () => {
-      const input = "bulbasaur";
-      const result1 = formatPokemonName(input);
-      const result2 = formatPokemonName(input);
-
-      expect(result1).toBe(result2);
-      expect(input).toBe("bulbasaur"); // Original unchanged
-    });
-  });
-
   describe("getPokemonTypeClass", () => {
     it("generates correct CSS class for normal type", () => {
       expect(getPokemonTypeClass("normal")).toBe("type-normal");

--- a/frontend/app/components/PokemonCard/PokemonCard.utils.ts
+++ b/frontend/app/components/PokemonCard/PokemonCard.utils.ts
@@ -1,11 +1,4 @@
 /**
- * Formats Pokemon name with first letter capitalized
- */
-export const formatPokemonName = (name: string): string => {
-  return name.charAt(0).toUpperCase() + name.slice(1);
-};
-
-/**
  * Generates CSS class for Pokemon type styling
  */
 export const getPokemonTypeClass = (type: string): string => {

--- a/frontend/app/components/RouteModal/BrowseRouteModal.tsx
+++ b/frontend/app/components/RouteModal/BrowseRouteModal.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import type { ReactNode } from "react";
+import { type BrowseSection, buildBrowseUrl } from "@/lib/browseUrls";
+import { parsePage } from "@/lib/pagination";
+import { parseSort } from "@/lib/sort";
+import RouteModal from "./RouteModal";
+
+interface BrowseRouteModalProps {
+  section: BrowseSection;
+  slug: string;
+  children: ReactNode;
+}
+
+export default function BrowseRouteModal({ section, slug, children }: BrowseRouteModalProps) {
+  const searchParams = useSearchParams();
+
+  const closeHref = buildBrowseUrl(section, slug, {
+    page: parsePage(searchParams.get("page")),
+    sort: parseSort(searchParams.get("sort")),
+  });
+
+  return (
+    <RouteModal closeHref={closeHref} showCloseButton={false}>
+      {children}
+    </RouteModal>
+  );
+}

--- a/frontend/app/components/RouteModal/index.ts
+++ b/frontend/app/components/RouteModal/index.ts
@@ -1,1 +1,2 @@
+export { default as BrowseRouteModal } from "./BrowseRouteModal";
 export { default } from "./RouteModal";

--- a/frontend/app/forms/[special]/components/FormsResults/FormsResults.module.css
+++ b/frontend/app/forms/[special]/components/FormsResults/FormsResults.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/frontend/app/forms/[special]/components/FormsResults/FormsResults.test.tsx
+++ b/frontend/app/forms/[special]/components/FormsResults/FormsResults.test.tsx
@@ -1,0 +1,168 @@
+import { useQuery } from "@apollo/client/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useSearchParams } from "next/navigation";
+import type { Pokemon } from "@/types";
+import FormsResults from "./FormsResults";
+
+vi.mock("@apollo/client/react", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("@/components/PokemonList", () => ({
+  __esModule: true,
+  default: ({ pokemon }: { pokemon: Pokemon[] }) => (
+    <ul data-testid="pokemon-list">
+      {pokemon.map((entry) => (
+        <li key={entry.id}>{entry.name}</li>
+      ))}
+    </ul>
+  ),
+  PokemonListSkeleton: ({ count }: { count: number }) => (
+    <div data-testid="pokemon-list-skeleton">{count}</div>
+  ),
+}));
+
+vi.mock("@/components/Pagination", () => ({
+  __esModule: true,
+  default: ({
+    currentPage,
+    totalItems,
+    onPageChange,
+  }: {
+    currentPage: number;
+    totalItems: number;
+    onPageChange: (page: number) => void;
+  }) => (
+    <button type="button" data-testid="pagination" onClick={() => onPageChange(currentPage + 1)}>
+      page {currentPage} of {totalItems}
+    </button>
+  ),
+}));
+
+const pokemon = [{ id: "10199", name: "pikachu-gmax" }] as Pokemon[];
+
+const setPage = (page: string) =>
+  vi
+    .mocked(useSearchParams)
+    .mockReturnValue(
+      new URLSearchParams(page ? `page=${page}` : "") as unknown as ReturnType<
+        typeof useSearchParams
+      >,
+    );
+
+const setResults = ({
+  loading = false,
+  total = 1,
+  data = pokemon,
+}: {
+  loading?: boolean;
+  total?: number;
+  data?: Pokemon[];
+} = {}) =>
+  vi.mocked(useQuery).mockReturnValue({
+    loading,
+    data: { pokemonForms: { pokemon: data, total } },
+  } as unknown as ReturnType<typeof useQuery>);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+  vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  setPage("");
+  setResults();
+});
+
+describe("FormsResults", () => {
+  describe("the query", () => {
+    it("asks the forms index for the collection", () => {
+      render(<FormsResults special="gmax" />);
+
+      expect(vi.mocked(useQuery).mock.calls[0][1]).toMatchObject({
+        variables: { query: "gmax", limit: 20, offset: 0 },
+      });
+    });
+
+    it("offsets by the page in the URL", () => {
+      setPage("3");
+
+      render(<FormsResults special="mega" />);
+
+      expect(vi.mocked(useQuery).mock.calls[0][1]).toMatchObject({
+        variables: { query: "mega", limit: 20, offset: 40 },
+      });
+    });
+  });
+
+  describe("rendering", () => {
+    it("names the collection", () => {
+      render(<FormsResults special="gmax" />);
+
+      expect(screen.getByRole("heading", { name: "Gigantamax Pokemon" })).toBeInTheDocument();
+    });
+
+    it("titles the other collection too", () => {
+      render(<FormsResults special="mega" />);
+
+      expect(screen.getByRole("heading", { name: "Mega Evolve Pokemon" })).toBeInTheDocument();
+    });
+
+    it("shows a full page of placeholders on the first load", () => {
+      vi.mocked(useQuery).mockReturnValue({
+        loading: true,
+        data: undefined,
+      } as unknown as ReturnType<typeof useQuery>);
+
+      render(<FormsResults special="gmax" />);
+
+      expect(screen.getByTestId("pokemon-list-skeleton")).toHaveTextContent("20");
+    });
+
+    it("keeps the previous grid up while the next page lands", () => {
+      vi.mocked(useQuery).mockReturnValue({
+        loading: true,
+        data: undefined,
+        previousData: { pokemonForms: { pokemon, total: 1 } },
+      } as unknown as ReturnType<typeof useQuery>);
+
+      render(<FormsResults special="gmax" />);
+
+      expect(screen.getByTestId("pokemon-list")).toHaveTextContent("pikachu-gmax");
+      expect(screen.queryByTestId("pokemon-list-skeleton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("paging", () => {
+    it("puts the next page in the URL without re-running the server page", async () => {
+      const user = userEvent.setup();
+      setResults({ total: 100 });
+
+      render(<FormsResults special="gmax" />);
+      await user.click(screen.getByTestId("pagination"));
+
+      expect(window.history.pushState).toHaveBeenCalledWith(null, "", "/forms/gmax?page=2");
+    });
+
+    it("clamps a page past the end of the collection", () => {
+      setPage("9");
+      setResults({ total: 21 });
+
+      render(<FormsResults special="gmax" />);
+
+      expect(window.history.replaceState).toHaveBeenCalledWith(null, "", "/forms/gmax?page=2");
+    });
+
+    it("leaves an empty collection alone rather than clamping to page zero", () => {
+      setPage("3");
+      setResults({ total: 0, data: [] });
+
+      render(<FormsResults special="gmax" />);
+
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/forms/[special]/components/FormsResults/FormsResults.tsx
+++ b/frontend/app/forms/[special]/components/FormsResults/FormsResults.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect } from "react";
+import HeroToolbar from "@/components/HeroToolbar";
+import ListHeader from "@/components/ListHeader";
+import Pagination from "@/components/Pagination";
+import { getTotalPages } from "@/components/Pagination/Pagination.util";
+import PokemonList, { PokemonListSkeleton } from "@/components/PokemonList";
+import SortToggle from "@/components/SortToggle";
+import { useScrolledPast, useSortParam } from "@/hooks";
+import { buildBrowseUrl } from "@/lib/browseUrls";
+import { parsePage } from "@/lib/pagination";
+import { GET_POKEMON_FORMS } from "@/lib/queries";
+import { SPECIAL_TITLES, type Special } from "@/lib/specials";
+import type { Pokemon, PokemonSort } from "@/types";
+import styles from "./FormsResults.module.css";
+
+interface FormsResultsProps {
+  special: Special;
+}
+
+const ITEMS_PER_PAGE = 20;
+
+export default function FormsResults({ special }: FormsResultsProps) {
+  const { ref: headingRef, scrolledPast } = useScrolledPast<HTMLHeadingElement>();
+  const searchParams = useSearchParams();
+  const page = parsePage(searchParams.get("page"));
+
+  const buildSortUrl = useCallback(
+    (next: PokemonSort) => buildBrowseUrl("forms", special, { page: 1, sort: next }),
+    [special],
+  );
+  const { sort, setSort } = useSortParam(buildSortUrl);
+
+  const { loading, data, previousData } = useQuery<{
+    pokemonForms: { pokemon: Pokemon[]; total: number };
+  }>(GET_POKEMON_FORMS, {
+    variables: {
+      query: special,
+      limit: ITEMS_PER_PAGE,
+      offset: (page - 1) * ITEMS_PER_PAGE,
+      sort,
+    },
+  });
+
+  const results = data?.pokemonForms ?? previousData?.pokemonForms;
+  const total = results?.total ?? 0;
+  const title = `${SPECIAL_TITLES[special]} Pokemon`;
+
+  useEffect(() => {
+    const totalPages = getTotalPages(total, ITEMS_PER_PAGE);
+    if (total > 0 && page > totalPages) {
+      window.history.replaceState(
+        null,
+        "",
+        buildBrowseUrl("forms", special, { page: totalPages, sort }),
+      );
+    }
+  }, [total, page, special, sort]);
+
+  const handlePageChange = useCallback(
+    (nextPage: number) => {
+      headingRef.current?.scrollIntoView({ behavior: "smooth" });
+      window.history.pushState(
+        null,
+        "",
+        buildBrowseUrl("forms", special, { page: nextPage, sort }),
+      );
+    },
+    [special, sort, headingRef],
+  );
+
+  return (
+    <section className={styles.container}>
+      {scrolledPast && (
+        <HeroToolbar
+          title={title}
+          titleSide="left"
+          aside={<SortToggle value={sort} onChange={setSort} />}
+        />
+      )}
+
+      <ListHeader title={title} level={1} sort={sort} onSortChange={setSort} ref={headingRef} />
+
+      {loading && !results ? (
+        <PokemonListSkeleton count={ITEMS_PER_PAGE} />
+      ) : (
+        <PokemonList pokemon={results?.pokemon ?? []} />
+      )}
+
+      <Pagination
+        currentPage={page}
+        onPageChange={handlePageChange}
+        totalItems={total}
+        itemsPerPage={ITEMS_PER_PAGE}
+      />
+    </section>
+  );
+}

--- a/frontend/app/forms/[special]/components/FormsResults/index.ts
+++ b/frontend/app/forms/[special]/components/FormsResults/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FormsResults";

--- a/frontend/app/forms/[special]/page.module.css
+++ b/frontend/app/forms/[special]/page.module.css
@@ -1,0 +1,4 @@
+.container {
+  width: 100%;
+  padding-bottom: 120px;
+}

--- a/frontend/app/forms/[special]/page.tsx
+++ b/frontend/app/forms/[special]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { parseSpecial, SPECIAL_TITLES, SPECIALS } from "@/lib/specials";
+import FormsResults from "./components/FormsResults";
+import styles from "./page.module.css";
+
+export const generateStaticParams = () => SPECIALS.map((special) => ({ special }));
+
+export async function generateMetadata(props: { params: Promise<{ special: string }> }) {
+  const { special } = await props.params;
+  const parsed = parseSpecial(special);
+
+  return { title: parsed ? SPECIAL_TITLES[parsed] : "Forms" };
+}
+
+export default async function Page(props: { params: Promise<{ special: string }> }) {
+  const { special } = await props.params;
+  const parsed = parseSpecial(special);
+
+  if (!parsed) notFound();
+
+  return (
+    <div className={styles.container}>
+      <Suspense fallback={null}>
+        <FormsResults key={parsed} special={parsed} />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/app/layout/Navbar/Navbar.util.test.tsx
+++ b/frontend/app/layout/Navbar/Navbar.util.test.tsx
@@ -49,17 +49,17 @@ describe("getPokedexItems", () => {
 });
 
 describe("getSpecialItems", () => {
-  it("links each curated collection to the search results", () => {
+  it("links each curated collection to its own page", () => {
     expect(getSpecialItems()).toEqual([
       {
         label: "Gigantamax",
-        href: "/search?special=gmax",
-        activeWhenSearchParamIncludes: { key: "special", value: "gmax" },
+        href: "/forms/gmax",
+        activeWhenPathnameEquals: "/forms/gmax",
       },
       {
         label: "Mega Evolve",
-        href: "/search?special=mega",
-        activeWhenSearchParamIncludes: { key: "special", value: "mega" },
+        href: "/forms/mega",
+        activeWhenPathnameEquals: "/forms/mega",
       },
     ]);
   });

--- a/frontend/app/layout/Navbar/Navbar.util.tsx
+++ b/frontend/app/layout/Navbar/Navbar.util.tsx
@@ -1,7 +1,8 @@
 import { BookOpen01, MarkerPin01, Star01, Tag01 } from "@untitled-ui/icons-react";
 import type { ReactNode } from "react";
 import { getPokemonTypeIcon } from "@/lib/pokemonTypeIcons";
-import { buildSearchUrl, SPECIAL_TITLES, SPECIALS } from "@/lib/searchFilters";
+import { buildSearchUrl } from "@/lib/searchFilters";
+import { SPECIAL_TITLES, SPECIALS } from "@/lib/specials";
 import { capitalize } from "@/lib/string";
 import type { PokemonPokedex, PokemonRegion, PokemonType } from "@/types";
 import type { NavItem } from "./NavbarItem";
@@ -58,8 +59,8 @@ export const getRegionItems = (regions: PokemonRegion[]): NavItem[] =>
 export const getSpecialItems = (): NavItem[] =>
   SPECIALS.map((special) => ({
     label: SPECIAL_TITLES[special],
-    href: buildSearchUrl({ special }),
-    activeWhenSearchParamIncludes: { key: "special", value: special },
+    href: `/forms/${special}`,
+    activeWhenPathnameEquals: `/forms/${special}`,
   }));
 
 /**

--- a/frontend/app/layout/Navbar/components/SearchFilters/SearchFilters.hooks.test.ts
+++ b/frontend/app/layout/Navbar/components/SearchFilters/SearchFilters.hooks.test.ts
@@ -163,17 +163,39 @@ describe("useSearchFilterForm", () => {
   describe("name suggestions", () => {
     it("looks up matching names and returns them as suggestions", async () => {
       mockQuery.mockResolvedValue({
-        data: { pokemonSearch: { pokemon: [{ id: "4", name: "charmander" }] } },
+        data: {
+          pokemonSearch: {
+            pokemon: [{ id: "4", speciesId: "4", speciesName: "charmander", name: "charmander" }],
+          },
+        },
       });
 
       const { result } = renderHook(() => useSearchFilterForm());
 
       await expect(result.current.loadSuggestions("char")).resolves.toEqual([
-        { id: "4", label: "charmander" },
+        { id: "4", label: "Charmander" },
       ]);
       expect(mockQuery).toHaveBeenCalledWith(
         expect.objectContaining({ variables: { query: "char", limit: 8 } }),
       );
+    });
+
+    it("suggests a base form by its species, not by the suffix the API spells", async () => {
+      mockQuery.mockResolvedValue({
+        data: {
+          pokemonSearch: {
+            pokemon: [
+              { id: "681", speciesId: "681", speciesName: "aegislash", name: "aegislash-shield" },
+            ],
+          },
+        },
+      });
+
+      const { result } = renderHook(() => useSearchFilterForm());
+
+      await expect(result.current.loadSuggestions("aegis")).resolves.toEqual([
+        { id: "681", label: "Aegislash" },
+      ]);
     });
 
     it("does not fetch for a query too short to narrow anything", async () => {

--- a/frontend/app/layout/Navbar/components/SearchFilters/SearchFilters.hooks.ts
+++ b/frontend/app/layout/Navbar/components/SearchFilters/SearchFilters.hooks.ts
@@ -5,6 +5,7 @@ import type { SearchSuggestion } from "@code-x/lago";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Key } from "react-aria-components";
+import { formatPokemonName } from "@/lib/formNames";
 import { GET_POKEMON_NAME_SUGGESTIONS } from "@/lib/queries";
 import {
   buildSearchUrl,
@@ -23,7 +24,9 @@ const MIN_SUGGESTION_LENGTH = 2;
 const SUGGESTION_LIMIT = 8;
 
 interface SuggestionsData {
-  pokemonSearch?: { pokemon: { id: string; name: string }[] } | null;
+  pokemonSearch?: {
+    pokemon: { id: string; speciesId: string; speciesName: string; name: string }[];
+  } | null;
 }
 
 export interface SearchFilterForm {
@@ -101,7 +104,10 @@ export function useSearchFilterForm(): SearchFilterForm {
           fetchPolicy: "cache-first",
         });
 
-        return (data?.pokemonSearch?.pokemon ?? []).map(({ id, name }) => ({ id, label: name }));
+        return (data?.pokemonSearch?.pokemon ?? []).map((pokemon) => ({
+          id: pokemon.id,
+          label: formatPokemonName(pokemon),
+        }));
       } catch {
         // A failed lookup means no suggestions, not a broken field — the query
         // is valid free text either way.

--- a/frontend/app/lib/browseUrls.test.ts
+++ b/frontend/app/lib/browseUrls.test.ts
@@ -4,6 +4,13 @@ describe("buildBrowseUrl", () => {
   it("builds a section's own page", () => {
     expect(buildBrowseUrl("region", "johto")).toBe("/region/johto");
     expect(buildBrowseUrl("type", "fire")).toBe("/type/fire");
+    expect(buildBrowseUrl("forms", "gmax")).toBe("/forms/gmax");
+  });
+
+  it("pages and sorts a form collection like any other section", () => {
+    expect(buildBrowseUrl("forms", "mega", { page: 2, sort: "NAME_ASC" })).toBe(
+      "/forms/mega?sort=NAME_ASC&page=2",
+    );
   });
 
   it("leaves the page off the first page and carries later ones", () => {

--- a/frontend/app/lib/browseUrls.ts
+++ b/frontend/app/lib/browseUrls.ts
@@ -2,8 +2,8 @@ import type { PokemonSort } from "@/types";
 import { encodeSort } from "./sort";
 
 /** The browse pages that list Pokemon under a slug — and open one over that
- *  list from a nested route. Both are laid out identically. */
-export type BrowseSection = "region" | "type";
+ *  list from a nested route. */
+export type BrowseSection = "region" | "type" | "forms";
 
 /**
  * Builds any URL in a browse section: the section's own page, or a Pokemon

--- a/frontend/app/lib/formNames.test.ts
+++ b/frontend/app/lib/formNames.test.ts
@@ -1,0 +1,105 @@
+import { formatFormName, formatPokemonName } from "./formNames";
+
+describe("formatFormName", () => {
+  describe("labelling a form beside its species", () => {
+    it("calls the base form Default, so there is a way back to it", () => {
+      expect(formatFormName("pikachu", "pikachu")).toBe("Default");
+    });
+
+    it("names the form alone, since the species is already in the heading", () => {
+      expect(formatFormName("pikachu-gmax", "pikachu")).toBe("Gigantamax");
+      expect(formatFormName("aegislash-blade", "aegislash")).toBe("Blade");
+    });
+
+    it("keeps a multi-word suffix whole", () => {
+      expect(formatFormName("charizard-mega-x", "charizard")).toBe("Mega X");
+      expect(formatFormName("charizard-mega-y", "charizard")).toBe("Mega Y");
+    });
+
+    it("spells regional variants the way people say them", () => {
+      expect(formatFormName("vulpix-alola", "vulpix")).toBe("Alolan");
+      expect(formatFormName("meowth-galar", "meowth")).toBe("Galarian");
+      expect(formatFormName("growlithe-hisui", "growlithe")).toBe("Hisuian");
+      expect(formatFormName("wooper-paldea", "wooper")).toBe("Paldean");
+    });
+
+    it("strips the species rather than splitting on the first hyphen", () => {
+      expect(formatFormName("mr-mime", "mr-mime")).toBe("Default");
+      expect(formatFormName("mr-mime-galar", "mr-mime")).toBe("Galarian");
+      expect(formatFormName("ho-oh", "ho-oh")).toBe("Default");
+      expect(formatFormName("porygon-z", "porygon-z")).toBe("Default");
+      expect(formatFormName("tapu-koko", "tapu-koko")).toBe("Default");
+    });
+
+    it("falls back to the whole slug for a form that does not extend its species", () => {
+      expect(formatFormName("darmanitan-galar-standard", "darmanitan")).toBe("Galarian Standard");
+      expect(formatFormName("unrelated", "pikachu")).toBe("Unrelated");
+    });
+  });
+
+  describe("labelling a Pokemon on its own", () => {
+    it("names the species and the form together", () => {
+      expect(formatFormName("pikachu-gmax")).toBe("Pikachu Gigantamax");
+      expect(formatFormName("charizard-mega-x")).toBe("Charizard Mega X");
+    });
+
+    it("capitalizes a plain name", () => {
+      expect(formatFormName("bulbasaur")).toBe("Bulbasaur");
+    });
+
+    it("reads a hyphenated species as its own name", () => {
+      expect(formatFormName("mr-mime")).toBe("Mr Mime");
+      expect(formatFormName("porygon-z")).toBe("Porygon Z");
+    });
+  });
+
+  it("passes an empty name straight through", () => {
+    expect(formatFormName("")).toBe("");
+    expect(formatFormName("", "pikachu")).toBe("");
+  });
+});
+
+describe("formatPokemonName", () => {
+  const pokemon = (id: string, speciesId: string, speciesName: string, name: string) => ({
+    id,
+    speciesId,
+    speciesName,
+    name,
+  });
+
+  it("names an ordinary Pokemon", () => {
+    expect(formatPokemonName(pokemon("1", "1", "bulbasaur", "bulbasaur"))).toBe("Bulbasaur");
+  });
+
+  it("names a base form by its species, not by the suffix the API spells", () => {
+    expect(formatPokemonName(pokemon("681", "681", "aegislash", "aegislash-shield"))).toBe(
+      "Aegislash",
+    );
+    expect(formatPokemonName(pokemon("778", "778", "mimikyu", "mimikyu-disguised"))).toBe(
+      "Mimikyu",
+    );
+    expect(formatPokemonName(pokemon("386", "386", "deoxys", "deoxys-normal"))).toBe("Deoxys");
+  });
+
+  it("keeps an alternate form's full label, since that is what tells it apart", () => {
+    expect(formatPokemonName(pokemon("10199", "25", "pikachu", "pikachu-gmax"))).toBe(
+      "Pikachu Gigantamax",
+    );
+    expect(formatPokemonName(pokemon("10026", "681", "aegislash", "aegislash-blade"))).toBe(
+      "Aegislash Blade",
+    );
+  });
+
+  it("leaves a hyphenated species whole rather than reading it as a form", () => {
+    expect(formatPokemonName(pokemon("122", "122", "mr-mime", "mr-mime"))).toBe("Mr Mime");
+    expect(formatPokemonName(pokemon("250", "250", "ho-oh", "ho-oh"))).toBe("Ho Oh");
+    expect(formatPokemonName(pokemon("474", "474", "porygon-z", "porygon-z"))).toBe("Porygon Z");
+    expect(formatPokemonName(pokemon("772", "772", "type-null", "type-null"))).toBe("Type Null");
+  });
+
+  it("names a regional variant of a hyphenated species", () => {
+    expect(formatPokemonName(pokemon("10168", "122", "mr-mime", "mr-mime-galar"))).toBe(
+      "Mr Mime Galarian",
+    );
+  });
+});

--- a/frontend/app/lib/formNames.ts
+++ b/frontend/app/lib/formNames.ts
@@ -1,0 +1,40 @@
+import { capitalize } from "./string";
+
+const FORM_LABELS: Record<string, string> = {
+  gmax: "Gigantamax",
+  alola: "Alolan",
+  galar: "Galarian",
+  hisui: "Hisuian",
+  paldea: "Paldean",
+};
+
+const DEFAULT_FORM_LABEL = "Default";
+
+const toLabel = (slug: string): string =>
+  slug
+    .split("-")
+    .filter(Boolean)
+    .map((token) => FORM_LABELS[token] ?? capitalize(token))
+    .join(" ");
+
+export const formatFormName = (name: string, speciesName?: string): string => {
+  if (!name) return name;
+  if (!speciesName) return toLabel(name);
+
+  if (name === speciesName) return DEFAULT_FORM_LABEL;
+
+  const prefix = `${speciesName}-`;
+  if (!name.startsWith(prefix)) return toLabel(name);
+
+  return toLabel(name.slice(prefix.length));
+};
+
+interface NameablePokemon {
+  id: string;
+  speciesId: string;
+  speciesName: string;
+  name: string;
+}
+
+export const formatPokemonName = ({ id, speciesId, speciesName, name }: NameablePokemon): string =>
+  id === speciesId ? formatFormName(speciesName) : formatFormName(name);

--- a/frontend/app/lib/pokemonUrls.test.ts
+++ b/frontend/app/lib/pokemonUrls.test.ts
@@ -1,0 +1,16 @@
+import { buildPokemonPath } from "./pokemonUrls";
+
+describe("buildPokemonPath", () => {
+  it("addresses the default form as the species' own page", () => {
+    expect(buildPokemonPath("25", "25")).toBe("/pokemon/25");
+  });
+
+  it("nests an alternate form under its species", () => {
+    expect(buildPokemonPath("25", "10199")).toBe("/pokemon/25/forms/10199");
+    expect(buildPokemonPath("6", "10034")).toBe("/pokemon/6/forms/10034");
+  });
+
+  it("escapes both segments", () => {
+    expect(buildPokemonPath("a b", "c/d")).toBe("/pokemon/a%20b/forms/c%2Fd");
+  });
+});

--- a/frontend/app/lib/pokemonUrls.ts
+++ b/frontend/app/lib/pokemonUrls.ts
@@ -1,0 +1,5 @@
+export const buildPokemonPath = (speciesId: string, pokemonId: string): string => {
+  const base = `/pokemon/${encodeURIComponent(speciesId)}`;
+
+  return pokemonId === speciesId ? base : `${base}/forms/${encodeURIComponent(pokemonId)}`;
+};

--- a/frontend/app/lib/queries.ts
+++ b/frontend/app/lib/queries.ts
@@ -16,6 +16,8 @@ export const GET_POKEMON_BY_TYPE = gql`
       offset
       pokemon {
         id
+        speciesId
+        speciesName
         name
         type
         image
@@ -46,6 +48,8 @@ export const SEARCH_POKEMON = gql`
       offset
       pokemon {
         id
+        speciesId
+        speciesName
         name
         type
         image
@@ -78,6 +82,40 @@ export const FILTER_POKEMON = gql`
       offset
       pokemon {
         id
+        speciesId
+        speciesName
+        name
+        type
+        image
+        stats {
+          hp
+          attack
+          defense
+          specialAttack
+          specialDefense
+          speed
+        }
+        abilitiesLite {
+          id
+          name
+          url
+          slot
+          isHidden
+        }
+      }
+    }
+  }
+`;
+
+export const GET_POKEMON_FORMS = gql`
+  query GetPokemonForms($query: String, $limit: Int, $offset: Int, $sort: PokemonSort) {
+    pokemonForms(query: $query, limit: $limit, offset: $offset, sort: $sort) {
+      total
+      offset
+      pokemon {
+        id
+        speciesId
+        speciesName
         name
         type
         image
@@ -108,6 +146,8 @@ export const GET_POKEMON_NAME_SUGGESTIONS = gql`
     pokemonSearch(query: $query, limit: $limit) {
       pokemon {
         id
+        speciesId
+        speciesName
         name
       }
     }
@@ -130,6 +170,8 @@ export const GET_POKEMON_BY_POKEDEX = gql`
       offset
       pokemon {
         id
+        speciesId
+        speciesName
         name
         type
         image
@@ -169,6 +211,8 @@ export const GET_POKEMON_BY_REGION = gql`
       offset
       pokemon {
         id
+        speciesId
+        speciesName
         name
         type
         image

--- a/frontend/app/lib/searchFilters.test.ts
+++ b/frontend/app/lib/searchFilters.test.ts
@@ -34,7 +34,6 @@ describe("parseSearchParams", () => {
       dualType: { primary: "fire", secondary: "flying" },
       regions: ["kanto"],
       pokedexes: ["kanto", "national"],
-      special: undefined,
       sort: "NAME_DESC",
       page: 3,
     });
@@ -83,16 +82,8 @@ describe("parseSearchParams", () => {
     expect(parseSearchParams({}).page).toBe(1);
   });
 
-  it("keeps a recognised special and drops anything else", () => {
-    expect(parseSearchParams({ special: "gmax" }).special).toBe("gmax");
-    expect(parseSearchParams({ special: " MEGA " }).special).toBe("mega");
-    expect(parseSearchParams({ special: "shiny" }).special).toBeUndefined();
-  });
-
-  it("lets free text win over special, since the schema has one query field", () => {
-    expect(parseSearchParams({ q: "char", special: "gmax" })).toEqual(
-      state({ q: "char", special: undefined }),
-    );
+  it("ignores a stale special param, which now has a route of its own", () => {
+    expect(parseSearchParams({ special: "gmax" })).toEqual(state());
   });
 
   it("does not mutate the shared empty filter", () => {
@@ -169,11 +160,6 @@ describe("buildSearchUrl", () => {
     );
   });
 
-  it("drops special when free text is set, matching how it is parsed back", () => {
-    expect(buildSearchUrl(state({ q: "char", special: "gmax" }))).toBe("/search?q=char");
-    expect(buildSearchUrl(state({ special: "gmax" }))).toBe("/search?special=gmax");
-  });
-
   it("escapes free text while leaving the list separator readable", () => {
     expect(buildSearchUrl(state({ q: "mr mime&", types: ["fire", "grass"] }))).toBe(
       "/search?q=mr+mime%26&types=fire,grass",
@@ -221,14 +207,6 @@ describe("toPokemonFilter", () => {
       regions: ["kanto"],
       pokedexes: ["national"],
     });
-  });
-
-  it("sends special as the query, since it is really a name substring", () => {
-    expect(toPokemonFilter(state({ special: "gmax" }))).toEqual({ query: "gmax" });
-  });
-
-  it("prefers free text over special", () => {
-    expect(toPokemonFilter(state({ q: "char", special: "gmax" }))).toEqual({ query: "char" });
   });
 
   it("copies the lists so the caller cannot reach back into the state", () => {
@@ -295,16 +273,10 @@ describe("hasActiveFilters", () => {
     );
     expect(hasActiveFilters(state({ regions: ["kanto"] }))).toBe(true);
     expect(hasActiveFilters(state({ pokedexes: ["national"] }))).toBe(true);
-    expect(hasActiveFilters(state({ special: "mega" }))).toBe(true);
   });
 });
 
 describe("getSearchHeading", () => {
-  it("names the collection for a special", () => {
-    expect(getSearchHeading(state({ special: "gmax" }))).toBe("Gigantamax Pokemon");
-    expect(getSearchHeading(state({ special: "mega" }))).toBe("Mega Evolve Pokemon");
-  });
-
   it("keeps the old search wording when free text is the only facet", () => {
     expect(getSearchHeading(state({ q: "char" }))).toBe('Search results for "char"');
   });

--- a/frontend/app/lib/searchFilters.ts
+++ b/frontend/app/lib/searchFilters.ts
@@ -3,17 +3,6 @@ import { parsePage } from "./pagination";
 import { DEFAULT_SORT, encodeSort, parseSort } from "./sort";
 import { titleCase } from "./string";
 
-/** The two curated collections the sidebar links to. They are not a facet of
- *  their own in the schema — each is really a name substring — so they ride in
- *  on `query` and only exist to keep their own heading. */
-export const SPECIALS = ["gmax", "mega"] as const;
-export type Special = (typeof SPECIALS)[number];
-
-export const SPECIAL_TITLES: Record<Special, string> = {
-  gmax: "Gigantamax",
-  mega: "Mega Evolve",
-};
-
 /** Everything `/search` can be asked for, parsed out of the URL. The lists are
  *  `readonly` because they are shared with lago's `MultiSelect`, whose `value`
  *  is a `readonly Key[]`, and because `EMPTY_SEARCH_FILTERS` below is a shared
@@ -24,7 +13,6 @@ export interface SearchFilterState {
   dualType?: DualTypeFilter;
   regions: readonly string[];
   pokedexes: readonly string[];
-  special?: Special;
   sort: PokemonSort;
   page: number;
 }
@@ -112,11 +100,6 @@ export const encodeDualType = (pair?: DualTypeFilter): string | undefined => {
   return joinSlugs([pair.primary, pair.secondary].sort());
 };
 
-const parseSpecial = (value: string | undefined): Special | undefined => {
-  const special = value?.trim().toLowerCase();
-  return SPECIALS.includes(special as Special) ? (special as Special) : undefined;
-};
-
 /**
  * Reads a whole filter out of a URL query. Unknown params are ignored and
  * malformed ones fall back to their empty value rather than throwing — a URL is
@@ -131,18 +114,12 @@ const parseSpecial = (value: string | undefined): Special | undefined => {
 export const parseSearchParams = (params: SearchParamsLike): SearchFilterState => {
   const q = (readParam(params, "q") ?? "").trim();
 
-  // `PokemonFilter` has a single `query` field, so free text and a `special`
-  // shortcut cannot both be honoured. Free text wins and the shortcut is
-  // dropped outright, so the URL, the heading and the form all agree.
-  const special = q ? undefined : parseSpecial(readParam(params, "special"));
-
   return {
     q,
     types: parseSlugList(readParam(params, "types")),
     dualType: parseDualType(readParam(params, "dual")),
     regions: parseSlugList(readParam(params, "regions")),
     pokedexes: parseSlugList(readParam(params, "pokedexes")),
-    special,
     sort: parseSort(readParam(params, "sort")),
     page: parsePage(readParam(params, "page")),
   };
@@ -168,10 +145,6 @@ export const buildSearchUrl = (state: Partial<SearchFilterState> = {}): string =
   append("dual", encodeDualType(state.dualType));
   append("regions", joinSlugs(state.regions));
   append("pokedexes", joinSlugs(state.pokedexes));
-  // Mirrors the precedence in parseSearchParams, so a URL never carries a
-  // `special` that reading it back would discard.
-  if (!q) append("special", state.special);
-
   append("sort", encodeSort(state.sort));
 
   const page = state.page ?? 1;
@@ -197,9 +170,7 @@ export const buildSearchUrl = (state: Partial<SearchFilterState> = {}): string =
 export const toPokemonFilter = (state: SearchFilterState): PokemonFilter => {
   const filter: PokemonFilter = {};
 
-  // `special` is only ever a name substring, and `query` is the one field for
-  // both, so the two share it.
-  const query = state.q.trim() || state.special;
+  const query = state.q.trim();
 
   if (query) filter.query = query;
   if (state.types.length) filter.types = [...state.types];
@@ -245,7 +216,7 @@ export const buildDualTypeOptions = (types: PokemonType[]): DualTypeOption[] => 
 export const hasActiveFilters = (state: SearchFilterState): boolean =>
   // Trimmed, because this is asked of a draft straight out of a text field as
   // well as of a parsed URL, and whitespace is not a filter.
-  Boolean(state.q.trim() || state.special || state.dualType) ||
+  Boolean(state.q.trim() || state.dualType) ||
   state.types.length > 0 ||
   state.regions.length > 0 ||
   state.pokedexes.length > 0;
@@ -280,7 +251,6 @@ const describeSoleFacet = (state: SearchFilterState): string | null => {
  * @returns The heading text
  */
 export const getSearchHeading = (state: SearchFilterState): string => {
-  if (state.special) return `${SPECIAL_TITLES[state.special]} Pokemon`;
   if (!hasActiveFilters(state)) return "All Pokemon";
 
   const facets = [

--- a/frontend/app/lib/server-queries.ts
+++ b/frontend/app/lib/server-queries.ts
@@ -6,6 +6,8 @@ const GET_POKEMON_BY_ID = gql`
   query GetPokemonById($id: ID!) {
     pokemon(id: $id) {
       id
+      speciesId
+      speciesName
       name
       type
       image
@@ -58,6 +60,12 @@ const GET_POKEMON_BY_ID = gql`
             }
           }
         }
+      }
+      forms {
+        id
+        name
+        image
+        isDefault
       }
     }
   }

--- a/frontend/app/lib/specials.test.ts
+++ b/frontend/app/lib/specials.test.ts
@@ -1,0 +1,26 @@
+import { parseSpecial, SPECIAL_TITLES, SPECIALS } from "./specials";
+
+describe("parseSpecial", () => {
+  it("accepts each collection", () => {
+    expect(parseSpecial("gmax")).toBe("gmax");
+    expect(parseSpecial("mega")).toBe("mega");
+  });
+
+  it("trims and lowercases, since this comes out of a URL", () => {
+    expect(parseSpecial(" MEGA ")).toBe("mega");
+  });
+
+  it("rejects anything else, so the route can 404 rather than list nothing", () => {
+    expect(parseSpecial("shiny")).toBeUndefined();
+    expect(parseSpecial("")).toBeUndefined();
+    expect(parseSpecial(undefined)).toBeUndefined();
+  });
+});
+
+describe("SPECIAL_TITLES", () => {
+  it("titles every collection", () => {
+    for (const special of SPECIALS) {
+      expect(SPECIAL_TITLES[special]).toBeTruthy();
+    }
+  });
+});

--- a/frontend/app/lib/specials.ts
+++ b/frontend/app/lib/specials.ts
@@ -1,0 +1,12 @@
+export const SPECIALS = ["gmax", "mega"] as const;
+export type Special = (typeof SPECIALS)[number];
+
+export const SPECIAL_TITLES: Record<Special, string> = {
+  gmax: "Gigantamax",
+  mega: "Mega Evolve",
+};
+
+export const parseSpecial = (value: string | undefined): Special | undefined => {
+  const special = value?.trim().toLowerCase();
+  return SPECIALS.includes(special as Special) ? (special as Special) : undefined;
+};

--- a/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.module.css
+++ b/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.module.css
@@ -1,0 +1,36 @@
+.select {
+  width: 200px;
+  flex-shrink: 0;
+
+  --field-background: rgba(255, 255, 255, 0.22);
+  --field-text-color: #fff;
+  --text-color: #fff;
+  --text-color-placeholder: rgba(255, 255, 255, 0.75);
+  --focus-ring-color: #fff;
+}
+
+.select :global(.react-aria-Group) {
+  --inset-border: rgba(255, 255, 255, 0.25);
+  --inset-highlight: transparent;
+  --inset-shadow-offset: 0;
+  --inset-shadow-size: 0;
+
+  backdrop-filter: blur(4px);
+}
+
+.select :global(.field-Button) {
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+
+.select :global(.field-Button):where([data-hovered], [data-pressed]) {
+  background: rgba(255, 255, 255, 0.34);
+}
+
+.select :global(.react-aria-Input) {
+  text-align: start;
+}
+
+.sprite img {
+  object-fit: contain;
+}

--- a/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.test.tsx
+++ b/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PokemonForm } from "@/types";
+import { FormSelect } from "./FormSelect";
+
+const replace = vi.fn();
+let pathname = "/pokemon/25";
+let search = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => pathname,
+  useSearchParams: () => new URLSearchParams(search),
+}));
+
+const forms: PokemonForm[] = [
+  {
+    id: "25",
+    name: "pikachu",
+    image: "https://example.com/25.png",
+    isDefault: true,
+  },
+  {
+    id: "10199",
+    name: "pikachu-gmax",
+    image: "https://example.com/10199.png",
+    isDefault: false,
+  },
+];
+
+const renderSelect = (props: Partial<React.ComponentProps<typeof FormSelect>> = {}) =>
+  render(
+    <FormSelect forms={forms} currentId="25" speciesId="25" speciesName="pikachu" {...props} />,
+  );
+
+const open = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("combobox", { name: "Form" }));
+  return screen.findByRole("listbox");
+};
+
+describe("FormSelect", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    pathname = "/pokemon/25";
+    search = "";
+  });
+
+  it("renders nothing when the Pokemon has no alternate form", () => {
+    const { container } = renderSelect({ forms: [forms[0]] });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for a Pokemon that carries no forms at all", () => {
+    const { container } = renderSelect({ forms: undefined });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers an option per form, named by the form alone", async () => {
+    const user = userEvent.setup();
+    renderSelect();
+
+    const listbox = await open(user);
+    expect(within(listbox).getByRole("option", { name: "Default" })).toBeInTheDocument();
+    expect(within(listbox).getByRole("option", { name: "Gigantamax" })).toBeInTheDocument();
+  });
+
+  it("shows a sprite beside each option", async () => {
+    const user = userEvent.setup();
+    renderSelect();
+
+    const listbox = await open(user);
+    const gmax = within(listbox).getByRole("option", { name: "Gigantamax" });
+
+    expect(gmax.querySelector("img")).toHaveAttribute("src", "https://example.com/10199.png");
+  });
+
+  it("starts on the form being displayed", () => {
+    renderSelect();
+
+    expect(screen.getByRole("combobox", { name: "Form" })).toHaveValue("Default");
+  });
+
+  it("starts on the alternate form when that is the page", () => {
+    renderSelect({ currentId: "10199" });
+
+    expect(screen.getByRole("combobox", { name: "Form" })).toHaveValue("Gigantamax");
+  });
+
+  it("routes to the picked form", async () => {
+    const user = userEvent.setup();
+    renderSelect();
+
+    const listbox = await open(user);
+    await user.click(within(listbox).getByRole("option", { name: "Gigantamax" }));
+
+    expect(replace).toHaveBeenCalledWith("/pokemon/25/forms/10199", { scroll: false });
+  });
+
+  it("routes back to the species when the default is picked", async () => {
+    pathname = "/pokemon/25/forms/10199";
+
+    const user = userEvent.setup();
+    renderSelect({ currentId: "10199" });
+
+    const listbox = await open(user);
+    await user.click(within(listbox).getByRole("option", { name: "Default" }));
+
+    expect(replace).toHaveBeenCalledWith("/pokemon/25", { scroll: false });
+  });
+
+  it("stays in the modal it was opened from, keeping the list's page and sort", async () => {
+    pathname = "/region/kanto/pokemon/25";
+    search = "page=2&sort=NAME_ASC";
+
+    const user = userEvent.setup();
+    renderSelect();
+
+    const listbox = await open(user);
+    await user.click(within(listbox).getByRole("option", { name: "Gigantamax" }));
+
+    expect(replace).toHaveBeenCalledWith(
+      "/region/kanto/pokemon/25/forms/10199?page=2&sort=NAME_ASC",
+      { scroll: false },
+    );
+  });
+
+  it("does not navigate when the form already shown is picked again", async () => {
+    const user = userEvent.setup();
+    renderSelect();
+
+    const listbox = await open(user);
+    await user.click(within(listbox).getByRole("option", { name: "Default" }));
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("shows a visible label", () => {
+    renderSelect();
+
+    expect(screen.getByText("Form")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.tsx
+++ b/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Avatar, Select, SelectItem, Text } from "@code-x/lago";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import type { Key } from "react-aria-components";
+import { formatFormName } from "@/lib/formNames";
+import type { PokemonForm } from "@/types";
+import styles from "./FormSelect.module.css";
+import { buildFormHref } from "./FormSelect.utils";
+
+interface FormSelectProps {
+  forms?: PokemonForm[];
+  currentId: string;
+  speciesId: string;
+  speciesName: string;
+  className?: string;
+}
+
+export function FormSelect({
+  forms,
+  currentId,
+  speciesId,
+  speciesName,
+  className,
+}: FormSelectProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  if (!forms || forms.length < 2) return null;
+
+  const handleChange = (key: Key | null) => {
+    if (key == null) return;
+
+    const formId = String(key);
+    if (formId === currentId) return;
+
+    router.replace(buildFormHref(pathname, searchParams.toString(), { speciesId, formId }), {
+      scroll: false,
+    });
+  };
+
+  return (
+    <Select
+      size="sm"
+      value={currentId}
+      onChange={handleChange}
+      label="Form"
+      className={[styles.select, className].filter(Boolean).join(" ")}
+    >
+      {forms.map((form) => {
+        const label = formatFormName(form.name, speciesName);
+
+        return (
+          <SelectItem key={form.id} id={form.id} textValue={label}>
+            <Avatar
+              src={form.image}
+              alt=""
+              name={label}
+              size="sm"
+              shape="square"
+              className={styles.sprite}
+            />
+            <Text slot="label">{label}</Text>
+          </SelectItem>
+        );
+      })}
+    </Select>
+  );
+}
+
+export default FormSelect;

--- a/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.utils.test.ts
+++ b/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.utils.test.ts
@@ -1,0 +1,78 @@
+import { buildFormHref } from "./FormSelect.utils";
+
+const target = (formId: string, speciesId = "25") => ({ speciesId, formId });
+
+describe("buildFormHref", () => {
+  it("nests the form under its species", () => {
+    expect(buildFormHref("/pokemon/25", "", target("10199"))).toBe("/pokemon/25/forms/10199");
+  });
+
+  it("swaps one form for another without deepening the path", () => {
+    expect(buildFormHref("/pokemon/25/forms/10199", "", target("10080"))).toBe(
+      "/pokemon/25/forms/10080",
+    );
+  });
+
+  it("drops the form segment when the default is picked", () => {
+    expect(buildFormHref("/pokemon/25/forms/10199", "", target("25"))).toBe("/pokemon/25");
+  });
+
+  it("stays in the region modal, keeping the list's page and sort", () => {
+    expect(buildFormHref("/region/kanto/pokemon/25", "page=2&sort=NAME_ASC", target("10199"))).toBe(
+      "/region/kanto/pokemon/25/forms/10199?page=2&sort=NAME_ASC",
+    );
+  });
+
+  it("swaps forms inside the region modal", () => {
+    expect(buildFormHref("/region/kanto/pokemon/25/forms/10199", "page=2", target("10080"))).toBe(
+      "/region/kanto/pokemon/25/forms/10080?page=2",
+    );
+  });
+
+  it("returns to the species inside the modal when the default is picked", () => {
+    expect(
+      buildFormHref("/type/fire/pokemon/6/forms/10034", "sort=NAME_ASC", target("6", "6")),
+    ).toBe("/type/fire/pokemon/6?sort=NAME_ASC");
+  });
+
+  it("stays in the type modal too", () => {
+    expect(buildFormHref("/type/fire/pokemon/6", "sort=NAME_ASC", target("10034", "6"))).toBe(
+      "/type/fire/pokemon/6/forms/10034?sort=NAME_ASC",
+    );
+  });
+
+  it("normalizes a form addressed by its own id onto the species", () => {
+    expect(buildFormHref("/pokemon/10199", "", target("10080"))).toBe("/pokemon/25/forms/10080");
+  });
+
+  it("tolerates a leading question mark on the search string", () => {
+    expect(buildFormHref("/type/fire/pokemon/6", "?page=3", target("10034", "6"))).toBe(
+      "/type/fire/pokemon/6/forms/10034?page=3",
+    );
+  });
+
+  it("leaves the query off when there is none", () => {
+    expect(buildFormHref("/region/kanto/pokemon/25", "", target("10199"))).toBe(
+      "/region/kanto/pokemon/25/forms/10199",
+    );
+  });
+
+  it("tolerates a trailing slash", () => {
+    expect(buildFormHref("/pokemon/25/", "", target("10199"))).toBe("/pokemon/25/forms/10199");
+  });
+
+  it("falls back to the Pokemon's own page off a detail route", () => {
+    expect(buildFormHref("/search", "q=char", target("10199"))).toBe("/pokemon/25/forms/10199");
+    expect(buildFormHref("/", "", target("25"))).toBe("/pokemon/25");
+  });
+
+  it("does not mistake the form collections route for a detail", () => {
+    expect(buildFormHref("/forms/gmax", "", target("10199"))).toBe("/pokemon/25/forms/10199");
+  });
+
+  it("encodes the ids", () => {
+    expect(buildFormHref("/pokemon/25", "", target("a b", "c d"))).toBe(
+      "/pokemon/c%20d/forms/a%20b",
+    );
+  });
+});

--- a/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.utils.ts
+++ b/frontend/app/pokemon/[id]/components/FormSelect/FormSelect.utils.ts
@@ -1,0 +1,23 @@
+import { buildPokemonPath } from "@/lib/pokemonUrls";
+
+const DETAIL_TAIL = /\/pokemon\/[^/]+(?:\/forms\/[^/]+)?\/?$/;
+
+interface FormTarget {
+  speciesId: string;
+  formId: string;
+}
+
+export const buildFormHref = (
+  pathname: string,
+  search: string,
+  { speciesId, formId }: FormTarget,
+): string => {
+  const tail = buildPokemonPath(speciesId, formId);
+
+  if (!DETAIL_TAIL.test(pathname)) return tail;
+
+  const path = pathname.replace(DETAIL_TAIL, tail);
+  const query = search.replace(/^\?/, "");
+
+  return query ? `${path}?${query}` : path;
+};

--- a/frontend/app/pokemon/[id]/components/FormSelect/index.ts
+++ b/frontend/app/pokemon/[id]/components/FormSelect/index.ts
@@ -1,0 +1,1 @@
+export { FormSelect as default, FormSelect } from "./FormSelect";

--- a/frontend/app/pokemon/[id]/components/PokemonDetail/PokemonDetail.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonDetail/PokemonDetail.tsx
@@ -43,7 +43,7 @@ export default function PokemonDetail({ pokemon, flush }: PokemonDetailProps) {
       {pokemon.evolution && hasEvolutions(pokemon.evolution) && (
         <PokemonSection title="Evolution" className={typeClass}>
           <div className={styles.evolutionGrid}>
-            <PokemonEvolution evolution={pokemon.evolution} currentId={String(pokemon.id)} />
+            <PokemonEvolution evolution={pokemon.evolution} currentId={String(pokemon.speciesId)} />
           </div>
         </PokemonSection>
       )}

--- a/frontend/app/pokemon/[id]/components/PokemonDetailContent/PokemonDetailContent.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonDetailContent/PokemonDetailContent.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react";
+import { getPokemonById } from "@/lib/server-queries";
+import PokemonDetail from "@/pokemon/[id]/components/PokemonDetail";
+import PokemonDetailSkeleton from "@/pokemon/[id]/components/PokemonDetail/PokemonDetailSkeleton";
+
+interface PokemonDetailContentProps {
+  id: string;
+  flush?: boolean;
+}
+
+async function Detail({ id, flush }: PokemonDetailContentProps) {
+  const pokemon = await getPokemonById(id);
+  return <PokemonDetail pokemon={pokemon} flush={flush} />;
+}
+
+export default function PokemonDetailContent({ id, flush }: PokemonDetailContentProps) {
+  return (
+    <Suspense key={id} fallback={<PokemonDetailSkeleton flush={flush} />}>
+      <Detail id={id} flush={flush} />
+    </Suspense>
+  );
+}

--- a/frontend/app/pokemon/[id]/components/PokemonDetailContent/index.ts
+++ b/frontend/app/pokemon/[id]/components/PokemonDetailContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PokemonDetailContent";

--- a/frontend/app/pokemon/[id]/components/PokemonEvolution/PokemonEvolution.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonEvolution/PokemonEvolution.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { formatPokemonName } from "@/components/PokemonCard/PokemonCard.utils";
+import { formatFormName } from "@/lib/formNames";
 import type { EvolutionChain, EvolutionNode } from "@/types/graphql";
 import styles from "./PokemonEvolution.module.css";
 import { getEvolutionCondition } from "./PokemonEvolution.utils";
@@ -30,7 +30,7 @@ const EvolutionStage = ({ node, isCurrent }: StageProps) => {
           className={styles.stageImage}
         />
       </div>
-      <span className={styles.stageName}>{formatPokemonName(node.name)}</span>
+      <span className={styles.stageName}>{formatFormName(node.name)}</span>
       <span className={styles.stageNumber}>{dexNumber}</span>
     </>
   );

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.test.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.test.tsx
@@ -4,10 +4,12 @@ import type { Pokemon } from "@/types";
 import { PokemonHero } from "./PokemonHero";
 
 const back = vi.fn();
+const replace = vi.fn();
 
-// Mock Next.js components
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ back }),
+  useRouter: () => ({ back, replace }),
+  usePathname: () => "/pokemon/4",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("next/image", () => ({
@@ -18,9 +20,19 @@ vi.mock("next/image", () => ({
 
 const charmander = {
   id: "4",
+  speciesId: "4",
+  speciesName: "charmander",
   name: "charmander",
   image: "https://example.com/4.png",
   type: ["Fire"],
+  forms: [
+    {
+      id: "4",
+      name: "charmander",
+      image: "https://example.com/4.png",
+      isDefault: true,
+    },
+  ],
 } as Pokemon;
 
 describe("PokemonHero", () => {
@@ -31,11 +43,44 @@ describe("PokemonHero", () => {
   it("renders the name as the page heading", () => {
     render(<PokemonHero pokemon={charmander} />);
 
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("charmander");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Charmander");
+  });
+
+  it("heads a form page with the species rather than the form slug", () => {
+    render(<PokemonHero pokemon={{ ...charmander, name: "charmander-gmax" } as Pokemon} />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Charmander");
+  });
+
+  it("heads with the species even when the default form's name carries a suffix", () => {
+    render(
+      <PokemonHero
+        pokemon={
+          {
+            ...charmander,
+            id: "681",
+            speciesId: "681",
+            speciesName: "aegislash",
+            name: "aegislash-shield",
+          } as Pokemon
+        }
+      />,
+    );
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Aegislash");
+    expect(screen.queryByRole("heading", { name: "Aegislash Shield" })).not.toBeInTheDocument();
   });
 
   it("renders the zero-padded dex number", () => {
     render(<PokemonHero pokemon={charmander} />);
+
+    expect(screen.getByText("#004")).toBeInTheDocument();
+  });
+
+  it("numbers a form by its species, not by its own id", () => {
+    render(
+      <PokemonHero pokemon={{ ...charmander, id: "10199", name: "charmander-gmax" } as Pokemon} />,
+    );
 
     expect(screen.getByText("#004")).toBeInTheDocument();
   });
@@ -78,5 +123,32 @@ describe("PokemonHero", () => {
     const { container } = render(<PokemonHero pokemon={charmander} flush />);
 
     expect(container.querySelector("section")).toHaveClass("flush");
+  });
+
+  describe("form switcher", () => {
+    const charmanderWithForms = {
+      ...charmander,
+      forms: [
+        ...(charmander.forms ?? []),
+        {
+          id: "10199",
+          name: "charmander-gmax",
+          image: "https://example.com/10199.png",
+          isDefault: false,
+        },
+      ],
+    } as Pokemon;
+
+    it("is left out when the Pokemon has no alternate form", () => {
+      render(<PokemonHero pokemon={charmander} />);
+
+      expect(screen.queryByRole("combobox", { name: "Form" })).not.toBeInTheDocument();
+    });
+
+    it("is offered once there is something to switch to", () => {
+      render(<PokemonHero pokemon={charmanderWithForms} />);
+
+      expect(screen.getByRole("combobox", { name: "Form" })).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.tsx
@@ -7,6 +7,8 @@ import BackButton from "@/components/BackButton";
 import HeroToolbar from "@/components/HeroToolbar";
 import PokemonTypePill from "@/components/PokemonTypePill";
 import { useScrolledPast } from "@/hooks";
+import { formatFormName, formatPokemonName } from "@/lib/formNames";
+import FormSelect from "@/pokemon/[id]/components/FormSelect";
 import type { Pokemon } from "@/types";
 import styles from "./PokemonHero.module.css";
 import { getDexNumber } from "./PokemonHero.utils";
@@ -24,13 +26,16 @@ interface PokemonHeroProps {
 export const PokemonHero = ({ pokemon, className, flush }: PokemonHeroProps) => {
   const { ref, scrolledPast } = useScrolledPast<HTMLElement>();
 
+  const forms = pokemon.forms ?? [];
+  const speciesName = pokemon.speciesName;
+
   return (
     <>
       {scrolledPast && (
         <HeroToolbar
           className={className}
           flush={flush}
-          title={pokemon.name}
+          title={formatPokemonName(pokemon)}
           aside={<BackButton size="sm">Back</BackButton>}
           icon={
             <Image
@@ -47,14 +52,20 @@ export const PokemonHero = ({ pokemon, className, flush }: PokemonHeroProps) => 
       <section ref={ref} className={clsx(styles.hero, flush && styles.flush, className)}>
         <div className={styles.heroToolbar}>
           <BackButton>Back</BackButton>
-          <span className={styles.pokemonNumber}>{getDexNumber(pokemon.id)}</span>
+          <span className={styles.pokemonNumber}>{getDexNumber(pokemon.speciesId)}</span>
         </div>
 
         <div className={styles.heroBody}>
           <div className={styles.heroInfo}>
             <Heading level={1} className={styles.pokemonName}>
-              {pokemon.name}
+              {formatFormName(speciesName)}
             </Heading>
+            <FormSelect
+              forms={forms}
+              currentId={pokemon.id}
+              speciesId={pokemon.speciesId}
+              speciesName={speciesName}
+            />
             <div className={styles.typesContainer}>
               {pokemon.type.map((type: string) => (
                 <PokemonTypePill key={type} type={type} className={styles.heroPill} />

--- a/frontend/app/pokemon/[id]/forms/[formId]/page.tsx
+++ b/frontend/app/pokemon/[id]/forms/[formId]/page.tsx
@@ -1,0 +1,7 @@
+import PokemonDetailContent from "@/pokemon/[id]/components/PokemonDetailContent";
+
+export default async function Page(props: { params: Promise<{ formId: string }> }) {
+  const { formId } = await props.params;
+
+  return <PokemonDetailContent id={formId} />;
+}

--- a/frontend/app/pokemon/[id]/page.tsx
+++ b/frontend/app/pokemon/[id]/page.tsx
@@ -1,19 +1,7 @@
-import { Suspense } from "react";
-import { getPokemonById } from "@/lib/server-queries";
-import PokemonDetail from "@/pokemon/[id]/components/PokemonDetail";
-import PokemonDetailSkeleton from "@/pokemon/[id]/components/PokemonDetail/PokemonDetailSkeleton";
-
-async function PokemonDetailContent({ id }: { id: string }) {
-  const pokemon = await getPokemonById(id);
-  return <PokemonDetail pokemon={pokemon} />;
-}
+import PokemonDetailContent from "@/pokemon/[id]/components/PokemonDetailContent";
 
 export default async function Page(props: { params: Promise<{ id: string }> }) {
-  const params = await props.params;
+  const { id } = await props.params;
 
-  return (
-    <Suspense fallback={<PokemonDetailSkeleton />}>
-      <PokemonDetailContent id={params.id} />
-    </Suspense>
-  );
+  return <PokemonDetailContent id={id} />;
 }

--- a/frontend/app/region/[name]/@detail/pokemon/[id]/forms/[formId]/page.tsx
+++ b/frontend/app/region/[name]/@detail/pokemon/[id]/forms/[formId]/page.tsx
@@ -1,0 +1,7 @@
+import PokemonDetailContent from "@/pokemon/[id]/components/PokemonDetailContent";
+
+export default async function Page(props: { params: Promise<{ formId: string }> }) {
+  const { formId } = await props.params;
+
+  return <PokemonDetailContent id={formId} flush />;
+}

--- a/frontend/app/region/[name]/@detail/pokemon/[id]/layout.tsx
+++ b/frontend/app/region/[name]/@detail/pokemon/[id]/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import { BrowseRouteModal } from "@/components/RouteModal";
+
+export default async function Layout(props: {
+  children: ReactNode;
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await props.params;
+
+  return (
+    <BrowseRouteModal section="region" slug={decodeURIComponent(name)}>
+      {props.children}
+    </BrowseRouteModal>
+  );
+}

--- a/frontend/app/region/[name]/@detail/pokemon/[id]/page.tsx
+++ b/frontend/app/region/[name]/@detail/pokemon/[id]/page.tsx
@@ -1,40 +1,7 @@
-import { Suspense } from "react";
-import RouteModal from "@/components/RouteModal";
-import { buildBrowseUrl } from "@/lib/browseUrls";
-import { parsePage } from "@/lib/pagination";
-import { getPokemonById } from "@/lib/server-queries";
-import { parseSort } from "@/lib/sort";
-import PokemonDetail from "@/pokemon/[id]/components/PokemonDetail";
-import PokemonDetailSkeleton from "@/pokemon/[id]/components/PokemonDetail/PokemonDetailSkeleton";
+import PokemonDetailContent from "@/pokemon/[id]/components/PokemonDetailContent";
 
-async function PokemonDetailContent({ id }: { id: string }) {
-  const pokemon = await getPokemonById(id);
-  return <PokemonDetail pokemon={pokemon} flush />;
-}
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const { id } = await props.params;
 
-/**
- * The @detail slot for /region/[name]/pokemon/[id]. Same loader and same
- * PokemonDetail as /pokemon/[id] — this only decides where it renders, and
- * where closing it goes: back to the region on the page it was opened from.
- */
-export default async function Page(props: {
-  params: Promise<{ name: string; id: string }>;
-  searchParams: Promise<{ page?: string; sort?: string }>;
-}) {
-  const [{ name, id }, { page, sort }] = await Promise.all([props.params, props.searchParams]);
-  const closeHref = buildBrowseUrl("region", decodeURIComponent(name), {
-    page: parsePage(page),
-    sort: parseSort(sort),
-  });
-
-  // No header: PokemonDetail opens with its own "Back" button, and a header bar
-  // with a second dismiss on top of it reads as chrome, especially on mobile
-  // where the modal is a full-screen sheet.
-  return (
-    <RouteModal closeHref={closeHref} showCloseButton={false}>
-      <Suspense fallback={<PokemonDetailSkeleton flush />}>
-        <PokemonDetailContent id={id} />
-      </Suspense>
-    </RouteModal>
-  );
+  return <PokemonDetailContent id={id} flush />;
 }

--- a/frontend/app/search/components/SearchResults/SearchResults.test.tsx
+++ b/frontend/app/search/components/SearchResults/SearchResults.test.tsx
@@ -127,12 +127,6 @@ describe("SearchResults", () => {
       ).toBeInTheDocument();
     });
 
-    it("keeps the curated collections' own heading", () => {
-      render(<SearchResults filters={filters({ special: "gmax" })} />);
-
-      expect(screen.getByRole("heading", { name: "Gigantamax Pokemon" })).toBeInTheDocument();
-    });
-
     it("shows a full page of placeholders on the first load", () => {
       vi.mocked(useQuery).mockReturnValue({
         loading: true,

--- a/frontend/app/type/[name]/@detail/pokemon/[id]/forms/[formId]/page.tsx
+++ b/frontend/app/type/[name]/@detail/pokemon/[id]/forms/[formId]/page.tsx
@@ -1,0 +1,7 @@
+import PokemonDetailContent from "@/pokemon/[id]/components/PokemonDetailContent";
+
+export default async function Page(props: { params: Promise<{ formId: string }> }) {
+  const { formId } = await props.params;
+
+  return <PokemonDetailContent id={formId} flush />;
+}

--- a/frontend/app/type/[name]/@detail/pokemon/[id]/layout.tsx
+++ b/frontend/app/type/[name]/@detail/pokemon/[id]/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import { BrowseRouteModal } from "@/components/RouteModal";
+
+export default async function Layout(props: {
+  children: ReactNode;
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await props.params;
+
+  return (
+    <BrowseRouteModal section="type" slug={decodeURIComponent(name)}>
+      {props.children}
+    </BrowseRouteModal>
+  );
+}

--- a/frontend/app/type/[name]/@detail/pokemon/[id]/page.tsx
+++ b/frontend/app/type/[name]/@detail/pokemon/[id]/page.tsx
@@ -1,40 +1,7 @@
-import { Suspense } from "react";
-import RouteModal from "@/components/RouteModal";
-import { buildBrowseUrl } from "@/lib/browseUrls";
-import { parsePage } from "@/lib/pagination";
-import { getPokemonById } from "@/lib/server-queries";
-import { parseSort } from "@/lib/sort";
-import PokemonDetail from "@/pokemon/[id]/components/PokemonDetail";
-import PokemonDetailSkeleton from "@/pokemon/[id]/components/PokemonDetail/PokemonDetailSkeleton";
+import PokemonDetailContent from "@/pokemon/[id]/components/PokemonDetailContent";
 
-async function PokemonDetailContent({ id }: { id: string }) {
-  const pokemon = await getPokemonById(id);
-  return <PokemonDetail pokemon={pokemon} flush />;
-}
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const { id } = await props.params;
 
-/**
- * The @detail slot for /type/[name]/pokemon/[id]. Same loader and same
- * PokemonDetail as /pokemon/[id] — this only decides where it renders, and
- * where closing it goes: back to the type on the page it was opened from.
- */
-export default async function Page(props: {
-  params: Promise<{ name: string; id: string }>;
-  searchParams: Promise<{ page?: string; sort?: string }>;
-}) {
-  const [{ name, id }, { page, sort }] = await Promise.all([props.params, props.searchParams]);
-  const closeHref = buildBrowseUrl("type", decodeURIComponent(name), {
-    page: parsePage(page),
-    sort: parseSort(sort),
-  });
-
-  // No header: PokemonDetail opens with its own "Back" button, and a header bar
-  // with a second dismiss on top of it reads as chrome, especially on mobile
-  // where the modal is a full-screen sheet.
-  return (
-    <RouteModal closeHref={closeHref} showCloseButton={false}>
-      <Suspense fallback={<PokemonDetailSkeleton flush />}>
-        <PokemonDetailContent id={id} />
-      </Suspense>
-    </RouteModal>
-  );
+  return <PokemonDetailContent id={id} flush />;
 }

--- a/frontend/app/types/graphql.ts
+++ b/frontend/app/types/graphql.ts
@@ -55,9 +55,12 @@ export type Pokemon = {
   abilities?: Maybe<Array<Ability>>;
   abilitiesLite: Array<AbilityLite>;
   evolution?: Maybe<EvolutionChain>;
+  forms?: Maybe<Array<PokemonForm>>;
   id: Scalars['ID']['output'];
   image: Scalars['String']['output'];
   name: Scalars['String']['output'];
+  speciesId: Scalars['ID']['output'];
+  speciesName: Scalars['String']['output'];
   stats: Stats;
   type: Array<Scalars['String']['output']>;
 };
@@ -82,6 +85,13 @@ export type PokemonFilter = {
   query?: InputMaybe<Scalars['String']['input']>;
   regions?: InputMaybe<Array<Scalars['String']['input']>>;
   types?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type PokemonForm = {
+  id: Scalars['ID']['output'];
+  image: Scalars['String']['output'];
+  isDefault: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
 };
 
 /** Results are ordered by the query's `sort`, national dex number by default. */
@@ -124,6 +134,7 @@ export type Query = {
   pokemonByRegion?: Maybe<PokemonList>;
   pokemonByType?: Maybe<PokemonList>;
   pokemonFilter?: Maybe<PokemonList>;
+  pokemonForms?: Maybe<PokemonList>;
   pokemonSearch?: Maybe<PokemonList>;
   region?: Maybe<RegionDetail>;
   regions: Array<PokemonRegion>;
@@ -170,6 +181,14 @@ export type QueryPokemonFilterArgs = {
   filter: PokemonFilter;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<PokemonSort>;
+};
+
+
+export type QueryPokemonFormsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
   sort?: InputMaybe<PokemonSort>;
 };
 

--- a/tests/navigation/navbar.spec.ts
+++ b/tests/navigation/navbar.spec.ts
@@ -70,9 +70,8 @@ test.describe("Navbar", () => {
 
     await page.waitForLoadState("networkidle");
 
-    // The curated collections are one facet of the shared search results now,
-    // rather than a filter on the home page
-    await expect(page).toHaveURL(/\/search\?special=gmax/);
+    // The curated collections have their own page rather than a search facet
+    await expect(page).toHaveURL(/\/forms\/gmax/);
     await expect(gigantamaxLink).toHaveAttribute("aria-current", "page");
     await expect(searchInput).toHaveValue("");
 


### PR DESCRIPTION
## Summary of changes

1. Introduced `pokemonForms` query to fetch Pokémon forms with pagination and sorting.
2. Updated GraphQL schema to include `speciesId` and `speciesName` in the `Pokemon` type.
3. Enhanced `PokemonAPI` to support fetching forms for species.
4. Added new `PokemonForm` type and updated related resolvers.
5. Updated tests and mocks to accommodate new functionality.

## Steps to test

1. Verify the new `pokemonForms` query in GraphQL playground.
2. CI Check
