### PR TITLE
feat: Add Pokémon descriptions to GraphQL API and frontend

### DIFF
--- a/backend/pokedex-graphql/src/datasources/pokemon-api.test.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.test.ts
@@ -161,6 +161,36 @@ describe("getFormsForSpecies", () => {
   });
 });
 
+describe("getDescriptionsForSpecies", () => {
+  it("returns the species' blurbs oldest first, with the newest last", async () => {
+    const descriptions = await api().getDescriptionsForSpecies("1");
+
+    expect(descriptions.at(-1)).toEqual({
+      text: "While it is young, it uses the nutrients in its seed.",
+      versions: ["shield"],
+    });
+  });
+
+  it("groups the games that ship identical text and skips other languages", async () => {
+    const descriptions = await api().getDescriptionsForSpecies("1");
+
+    expect(descriptions).toEqual([
+      {
+        text: "A strange seed was planted on its back at birth.",
+        versions: ["red"],
+      },
+      {
+        text: "It can go for days without eating a single morsel.",
+        versions: ["blue", "leafgreen"],
+      },
+      {
+        text: "While it is young, it uses the nutrients in its seed.",
+        versions: ["shield"],
+      },
+    ]);
+  });
+});
+
 describe("getEvolutionForSpecies", () => {
   it("resolves a chain for a species", async () => {
     const chain = await api().getEvolutionForSpecies("1");

--- a/backend/pokedex-graphql/src/datasources/pokemon-api.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.ts
@@ -7,6 +7,7 @@ import type {
   EvolutionNode,
   PokedexDetail,
   Pokemon,
+  PokemonDescription,
   PokemonForm,
   PokemonPokedex,
   PokemonRegion,
@@ -21,6 +22,7 @@ import {
   convertPokemonEntityToPokemon,
   getEvolutionDetail,
   getIdFromUrl,
+  getSpeciesDescriptions,
   isForm,
   isSpecies,
   toPokemonIndex,
@@ -142,6 +144,12 @@ export class PokemonAPI extends RESTDataSource {
       id: chainResponse.id.toString(),
       chain: await this.buildEvolutionNode(chainResponse.chain),
     };
+  }
+
+  async getDescriptionsForSpecies(speciesId: string): Promise<PokemonDescription[]> {
+    const species = await this.getPokemonSpecies(speciesId);
+
+    return getSpeciesDescriptions(species);
   }
 
   async getFormsForSpecies(speciesId: string): Promise<PokemonForm[]> {

--- a/backend/pokedex-graphql/src/datasources/pokemon-api.types.ts
+++ b/backend/pokedex-graphql/src/datasources/pokemon-api.types.ts
@@ -27,6 +27,12 @@ export type FlavorTextEntry = {
   version_group: NamedAPIResource;
 };
 
+export type SpeciesFlavorTextEntry = {
+  flavor_text: string;
+  language: NamedAPIResource;
+  version: NamedAPIResource;
+};
+
 export type NameEntry = {
   name: string;
   language: NamedAPIResource;
@@ -166,6 +172,8 @@ export type PokemonSpecies = {
   evolution_chain: {
     url: string;
   };
+  // Ordered oldest game first, as PokeAPI ships it.
+  flavor_text_entries: SpeciesFlavorTextEntry[];
   varieties: PokemonSpeciesVariety[];
 };
 

--- a/backend/pokedex-graphql/src/mocks/pokemon.ts
+++ b/backend/pokedex-graphql/src/mocks/pokemon.ts
@@ -404,12 +404,46 @@ export const pokemonEntity: {
   ],
 };
 
+const version = (name: string) => ({
+  name,
+  url: `https://pokeapi.co/api/v2/version/${name}/`,
+});
+
+const english = { name: "en", url: "https://pokeapi.co/api/v2/language/9/" };
+
 export const pokemonSpecies: PokemonSpecies = {
   id: 1,
   name: "bulbasaur",
   evolution_chain: {
     url: "https://pokeapi.co/api/v2/evolution-chain/1/",
   },
+  flavor_text_entries: [
+    {
+      flavor_text: "A strange seed was\nplanted on its\nback at birth.",
+      language: english,
+      version: version("red"),
+    },
+    {
+      flavor_text: "It can go for days\nwithout eating a\nsingle morsel.",
+      language: english,
+      version: version("blue"),
+    },
+    {
+      flavor_text: "Une graine étrange\nlui a été plantée\ndans le dos.",
+      language: { name: "fr", url: "https://pokeapi.co/api/v2/language/5/" },
+      version: version("red"),
+    },
+    {
+      flavor_text: "It can go for days\nwithout eating a\nsingle morsel.",
+      language: english,
+      version: version("leafgreen"),
+    },
+    {
+      flavor_text: "While it is young,\nit uses the nutri\u00ad\nents in its seed.",
+      language: english,
+      version: version("shield"),
+    },
+  ],
   varieties: [
     {
       is_default: true,

--- a/backend/pokedex-graphql/src/resolvers.ts
+++ b/backend/pokedex-graphql/src/resolvers.ts
@@ -20,9 +20,9 @@ const resolveFacets = (
         Promise.all((types ?? []).map((type) => pokemonAPI.getPokemonByType(type))),
         dualType
           ? Promise.all([
-            pokemonAPI.getPokemonByType(dualType.primary),
-            pokemonAPI.getPokemonByType(dualType.secondary),
-          ])
+              pokemonAPI.getPokemonByType(dualType.primary),
+              pokemonAPI.getPokemonByType(dualType.secondary),
+            ])
           : Promise.resolve([]),
       ]).then(([anyOf, bothOf]) => union([...anyOf, intersect(bothOf)])),
     );

--- a/backend/pokedex-graphql/src/resolvers.ts
+++ b/backend/pokedex-graphql/src/resolvers.ts
@@ -4,6 +4,7 @@ import { logger } from "./logger.js";
 import { type PokemonFilter, PokemonSort, type Resolvers } from "./types.js";
 import { intersect, sortResults, union } from "./utils/filter.js";
 import { getPaginatedResults } from "./utils/pagination.js";
+import { getLatestDescription } from "./utils/pokemon.js";
 import { buildPokemonMatchups } from "./utils/type.js";
 
 const resolveFacets = (
@@ -19,9 +20,9 @@ const resolveFacets = (
         Promise.all((types ?? []).map((type) => pokemonAPI.getPokemonByType(type))),
         dualType
           ? Promise.all([
-              pokemonAPI.getPokemonByType(dualType.primary),
-              pokemonAPI.getPokemonByType(dualType.secondary),
-            ])
+            pokemonAPI.getPokemonByType(dualType.primary),
+            pokemonAPI.getPokemonByType(dualType.secondary),
+          ])
           : Promise.resolve([]),
       ]).then(([anyOf, bothOf]) => union([...anyOf, intersect(bothOf)])),
     );
@@ -405,6 +406,25 @@ export const resolvers: Resolvers = {
       } catch (error) {
         logger.error("Error resolving abilities:", error);
         throw error;
+      }
+    },
+    description: async ({ id, speciesId }, _, { dataSources }) => {
+      logger.info(`Resolving description for Pokemon ${id} (species ${speciesId})`);
+      try {
+        const descriptions = await dataSources.pokemonAPI.getDescriptionsForSpecies(speciesId);
+        return getLatestDescription(descriptions);
+      } catch (error) {
+        logger.error(`Error resolving description for Pokemon ${id}:`, error);
+        return null;
+      }
+    },
+    descriptions: async ({ id, speciesId }, _, { dataSources }) => {
+      logger.info(`Resolving descriptions for Pokemon ${id} (species ${speciesId})`);
+      try {
+        return await dataSources.pokemonAPI.getDescriptionsForSpecies(speciesId);
+      } catch (error) {
+        logger.error(`Error resolving descriptions for Pokemon ${id}:`, error);
+        return null;
       }
     },
     evolution: async ({ id, speciesId }, _, { dataSources }) => {

--- a/backend/pokedex-graphql/src/schema.generated.ts
+++ b/backend/pokedex-graphql/src/schema.generated.ts
@@ -92,9 +92,16 @@ type Pokemon {
   stats: Stats!
   abilitiesLite: [AbilityLite!]!
   abilities: [Ability!]
+  description: String
+  descriptions: [PokemonDescription!]
   evolution: EvolutionChain
   forms: [PokemonForm!]
   matchups: PokemonMatchups
+}
+
+type PokemonDescription {
+  versions: [String!]!
+  text: String!
 }
 
 type PokemonForm {

--- a/backend/pokedex-graphql/src/schema.graphql
+++ b/backend/pokedex-graphql/src/schema.graphql
@@ -90,9 +90,16 @@ type Pokemon {
   stats: Stats!
   abilitiesLite: [AbilityLite!]!
   abilities: [Ability!]
+  description: String
+  descriptions: [PokemonDescription!]
   evolution: EvolutionChain
   forms: [PokemonForm!]
   matchups: PokemonMatchups
+}
+
+type PokemonDescription {
+  versions: [String!]!
+  text: String!
 }
 
 type PokemonForm {

--- a/backend/pokedex-graphql/src/types.ts
+++ b/backend/pokedex-graphql/src/types.ts
@@ -94,6 +94,8 @@ export type Pokemon = {
   __typename?: 'Pokemon';
   abilities?: Maybe<Array<Ability>>;
   abilitiesLite: Array<AbilityLite>;
+  description?: Maybe<Scalars['String']['output']>;
+  descriptions?: Maybe<Array<PokemonDescription>>;
   evolution?: Maybe<EvolutionChain>;
   forms?: Maybe<Array<PokemonForm>>;
   id: Scalars['ID']['output'];
@@ -104,6 +106,12 @@ export type Pokemon = {
   speciesName: Scalars['String']['output'];
   stats: Stats;
   type: Array<Scalars['String']['output']>;
+};
+
+export type PokemonDescription = {
+  __typename?: 'PokemonDescription';
+  text: Scalars['String']['output'];
+  versions: Array<Scalars['String']['output']>;
 };
 
 /**
@@ -438,6 +446,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   PokedexDetail: ResolverTypeWrapper<PokedexDetail>;
   Pokemon: ResolverTypeWrapper<Pokemon>;
+  PokemonDescription: ResolverTypeWrapper<PokemonDescription>;
   PokemonFilter: PokemonFilter;
   PokemonForm: ResolverTypeWrapper<PokemonForm>;
   PokemonList: ResolverTypeWrapper<PokemonList>;
@@ -469,6 +478,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int']['output'];
   PokedexDetail: PokedexDetail;
   Pokemon: Pokemon;
+  PokemonDescription: PokemonDescription;
   PokemonFilter: PokemonFilter;
   PokemonForm: PokemonForm;
   PokemonList: PokemonList;
@@ -536,6 +546,8 @@ export type PokedexDetailResolvers<ContextType = DataSourceContext, ParentType e
 export type PokemonResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['Pokemon'] = ResolversParentTypes['Pokemon']> = {
   abilities?: Resolver<Maybe<Array<ResolversTypes['Ability']>>, ParentType, ContextType>;
   abilitiesLite?: Resolver<Array<ResolversTypes['AbilityLite']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  descriptions?: Resolver<Maybe<Array<ResolversTypes['PokemonDescription']>>, ParentType, ContextType>;
   evolution?: Resolver<Maybe<ResolversTypes['EvolutionChain']>, ParentType, ContextType>;
   forms?: Resolver<Maybe<Array<ResolversTypes['PokemonForm']>>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -546,6 +558,11 @@ export type PokemonResolvers<ContextType = DataSourceContext, ParentType extends
   speciesName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   stats?: Resolver<ResolversTypes['Stats'], ParentType, ContextType>;
   type?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PokemonDescriptionResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonDescription'] = ResolversParentTypes['PokemonDescription']> = {
+  text?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  versions?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type PokemonFormResolvers<ContextType = DataSourceContext, ParentType extends ResolversParentTypes['PokemonForm'] = ResolversParentTypes['PokemonForm']> = {
@@ -656,6 +673,7 @@ export type Resolvers<ContextType = DataSourceContext> = {
   EvolutionNode?: EvolutionNodeResolvers<ContextType>;
   PokedexDetail?: PokedexDetailResolvers<ContextType>;
   Pokemon?: PokemonResolvers<ContextType>;
+  PokemonDescription?: PokemonDescriptionResolvers<ContextType>;
   PokemonForm?: PokemonFormResolvers<ContextType>;
   PokemonList?: PokemonListResolvers<ContextType>;
   PokemonMatchups?: PokemonMatchupsResolvers<ContextType>;

--- a/backend/pokedex-graphql/src/utils/pokemon.test.ts
+++ b/backend/pokedex-graphql/src/utils/pokemon.test.ts
@@ -2,6 +2,8 @@ import type {
   EvolutionDetail,
   PokemonAbility,
   PokemonEntity,
+  PokemonSpecies,
+  SpeciesFlavorTextEntry,
 } from "../datasources/pokemon-api.types";
 import type { AbilityLite } from "../types";
 import {
@@ -9,10 +11,12 @@ import {
   convertPokemonEntityToPokemon,
   getEvolutionDetail,
   getIdFromUrl,
+  getLatestDescription,
   getPokemonAbilitiesLite,
   getPokemonDefaultImageUrl,
   getPokemonStats,
   getPokemonTypes,
+  getSpeciesDescriptions,
   toPokemonIndex,
 } from "./pokemon";
 
@@ -1311,5 +1315,135 @@ describe("toPokemonIndex", () => {
     const sorted = entries.map(toPokemonIndex).sort((a, b) => a.number - b.number);
 
     expect(sorted.map((p) => p.name)).toEqual(["bulbasaur", "ivysaur", "venusaur"]);
+  });
+});
+
+const flavorEntry = (
+  flavor_text: string,
+  version: string,
+  language = "en",
+): SpeciesFlavorTextEntry => ({
+  flavor_text,
+  language: { name: language, url: "" },
+  version: { name: version, url: "" },
+});
+
+const speciesWithEntries = (flavor_text_entries: SpeciesFlavorTextEntry[]): PokemonSpecies => ({
+  id: 1,
+  name: "bulbasaur",
+  evolution_chain: { url: "" },
+  flavor_text_entries,
+  varieties: [],
+});
+
+describe("getSpeciesDescriptions", () => {
+  it("should unwrap the text boxes' hard line breaks and form feeds", () => {
+    const species = speciesWithEntries([
+      flavorEntry(
+        "When several of\nthese POKéMON\ngather, their\felectricity could\nbuild.",
+        "red",
+      ),
+    ]);
+
+    expect(getSpeciesDescriptions(species)).toEqual([
+      {
+        text: "When several of these POKéMON gather, their electricity could build.",
+        versions: ["red"],
+      },
+    ]);
+  });
+
+  it("should close up a word the text box split with a soft hyphen", () => {
+    const species = speciesWithEntries([
+      flavorEntry("It checks its sur\u00ad\nroundings for light\u00ad\nning.", "gold"),
+    ]);
+
+    expect(getSpeciesDescriptions(species)[0].text).toBe(
+      "It checks its surroundings for lightning.",
+    );
+  });
+
+  it("should skip entries in other languages", () => {
+    const species = speciesWithEntries([
+      flavorEntry("A strange seed.", "red"),
+      flavorEntry("Une graine étrange.", "red", "fr"),
+    ]);
+
+    expect(getSpeciesDescriptions(species)).toEqual([
+      { text: "A strange seed.", versions: ["red"] },
+    ]);
+  });
+
+  it("should collapse the paired games that ship identical text", () => {
+    const species = speciesWithEntries([
+      flavorEntry("A strange seed.", "red"),
+      flavorEntry("A strange seed.", "blue"),
+    ]);
+
+    expect(getSpeciesDescriptions(species)).toEqual([
+      { text: "A strange seed.", versions: ["red", "blue"] },
+    ]);
+  });
+
+  it("should collapse reused text even when the games are generations apart", () => {
+    // Charizard really does this: its Sword entry repeats its Diamond one.
+    const species = speciesWithEntries([
+      flavorEntry("Spits fire hot enough to melt boulders.", "diamond"),
+      flavorEntry("Flies in search of powerful opponents.", "black"),
+      flavorEntry("Spits fire hot enough to melt boulders.", "sword"),
+    ]);
+
+    expect(getSpeciesDescriptions(species)).toEqual([
+      { text: "Flies in search of powerful opponents.", versions: ["black"] },
+      {
+        text: "Spits fire hot enough to melt boulders.",
+        versions: ["diamond", "sword"],
+      },
+    ]);
+  });
+
+  it("should place a reused blurb last when its newest game is the newest overall", () => {
+    // The anchor is the group's newest game, not its first — which is what keeps
+    // the last entry the newest blurb for getLatestDescription to read.
+    const species = speciesWithEntries([
+      flavorEntry("Old text.", "red"),
+      flavorEntry("Newer text.", "gold"),
+      flavorEntry("Old text.", "shield"),
+    ]);
+
+    expect(getSpeciesDescriptions(species).at(-1)).toEqual({
+      text: "Old text.",
+      versions: ["red", "shield"],
+    });
+  });
+
+  it("should drop entries whose text is only whitespace", () => {
+    const species = speciesWithEntries([
+      flavorEntry("   \n\f  ", "red"),
+      flavorEntry("A strange seed.", "blue"),
+    ]);
+
+    expect(getSpeciesDescriptions(species)).toEqual([
+      { text: "A strange seed.", versions: ["blue"] },
+    ]);
+  });
+
+  it("should return an empty list for a species with no blurbs", () => {
+    expect(getSpeciesDescriptions(speciesWithEntries([]))).toEqual([]);
+  });
+});
+
+describe("getLatestDescription", () => {
+  it("should return the last blurb, which is the newest", () => {
+    expect(
+      getLatestDescription([
+        { text: "Old text.", versions: ["red"] },
+        { text: "Newest text.", versions: ["shield"] },
+      ]),
+    ).toBe("Newest text.");
+  });
+
+  it("should return null when the species has no blurbs", () => {
+    expect(getLatestDescription([])).toBeNull();
   });
 });

--- a/backend/pokedex-graphql/src/utils/pokemon.ts
+++ b/backend/pokedex-graphql/src/utils/pokemon.ts
@@ -4,9 +4,10 @@ import type {
   PokemonAbility,
   PokemonEntity,
   PokemonIndex,
+  PokemonSpecies,
   PokemonStat,
 } from "../datasources/pokemon-api.types.js";
-import type { AbilityLite, Pokemon, Stats } from "../types.js";
+import type { AbilityLite, Pokemon, PokemonDescription, Stats } from "../types.js";
 
 export const FORM_ID_THRESHOLD = 10000;
 
@@ -111,6 +112,34 @@ export const getPokemonStats = (pokemon: PokemonEntity) => {
   });
   return statsObj;
 };
+
+const normalizeFlavorText = (text: string): string =>
+  text
+    .replace(/\u00ad\s*/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/** Every English blurb for a species, deduplicated and oldest first. */
+export const getSpeciesDescriptions = (species: PokemonSpecies): PokemonDescription[] => {
+  const groups = new Map<string, string[]>();
+
+  for (const entry of species.flavor_text_entries ?? []) {
+    if (entry.language.name !== "en") continue;
+
+    const text = normalizeFlavorText(entry.flavor_text);
+    if (!text) continue;
+
+    const versions = groups.get(text) ?? [];
+    versions.push(entry.version.name);
+    groups.delete(text);
+    groups.set(text, versions);
+  }
+
+  return Array.from(groups, ([text, versions]) => ({ text, versions }));
+};
+
+export const getLatestDescription = (descriptions: PokemonDescription[]): string | null =>
+  descriptions.at(-1)?.text ?? null;
 
 export const convertAbilityLiteToAbility = (data: PokemonAbility, abilityLite: AbilityLite) => {
   return {

--- a/frontend/app/lib/server-queries.ts
+++ b/frontend/app/lib/server-queries.ts
@@ -11,6 +11,7 @@ const GET_POKEMON_BY_ID = gql`
       name
       type
       image
+      description
       stats {
         hp
         attack

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.module.css
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.module.css
@@ -36,6 +36,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
   /* Named because the flush variant restates it with the scrollbar lane added
      on, and the two must stay in step across breakpoints. */
@@ -61,7 +62,7 @@
   align-items: center;
   gap: 2rem;
   padding: 1.5rem 3rem;
-  max-height: 310px;
+  min-height: 310px;
   /* Clips the bleeding artwork at the toolbar edge so it can't
      show through the toolbar's translucent band */
   overflow: hidden;
@@ -116,6 +117,18 @@
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
+.heroMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  /* The toolbar wraps this cluster onto its own line once the type names get
+     long enough on a narrow viewport. space-between would park it at the start
+     of that line; auto keeps the number's hard-right anchor either way. */
+  margin-left: auto;
+  gap: 0.75rem;
+}
+
 .typesContainer {
   display: flex;
   flex-wrap: wrap;
@@ -123,11 +136,23 @@
 }
 
 .typesContainer .heroPill {
+  /* Matched to .pokemonNumber, which the pills now sit beside — the cluster
+     wants one silhouette, and the pill's padding alone lands 2px taller. */
+  height: 30px;
   background: rgba(255, 255, 255, 0.22);
   color: #fff;
   border: 1px solid rgba(255, 255, 255, 0.25);
   box-shadow: none;
   backdrop-filter: blur(4px);
+}
+
+.description {
+  margin: 0;
+  max-width: 52ch;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 .heroImage {
@@ -184,6 +209,10 @@
 
   .heroInfo {
     align-items: center;
+  }
+
+  .description {
+    margin-inline: auto;
   }
 
   .pokemonName {

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.test.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.test.tsx
@@ -98,6 +98,37 @@ describe("PokemonHero", () => {
     expect(screen.getByText("Poison")).toBeInTheDocument();
   });
 
+  it("renders the type pills in the toolbar alongside the dex number", () => {
+    const { container } = render(
+      <PokemonHero pokemon={{ ...charmander, type: ["Grass", "Poison"] } as Pokemon} />,
+    );
+
+    // Both readings share the number's strip rather than sitting down in the
+    // body, which is where the blurb goes now.
+    const toolbar = container.querySelector(".heroToolbar");
+    expect(toolbar).toContainElement(screen.getByText("Grass"));
+    expect(toolbar).toContainElement(screen.getByText("Poison"));
+    expect(toolbar).toContainElement(screen.getByText("#004"));
+  });
+
+  describe("description", () => {
+    const blurb = "It has a preference for hot things.";
+
+    it("renders the blurb under the name", () => {
+      render(<PokemonHero pokemon={{ ...charmander, description: blurb } as Pokemon} />);
+
+      expect(screen.getByText(blurb)).toBeInTheDocument();
+    });
+
+    it("is left out entirely when the species has no blurb", () => {
+      const { container } = render(
+        <PokemonHero pokemon={{ ...charmander, description: null } as Pokemon} />,
+      );
+
+      expect(container.querySelector("p")).not.toBeInTheDocument();
+    });
+  });
+
   it("navigates back when the toolbar button is clicked", async () => {
     const user = userEvent.setup();
     render(<PokemonHero pokemon={charmander} />);

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHero.tsx
@@ -52,7 +52,14 @@ export const PokemonHero = ({ pokemon, className, flush }: PokemonHeroProps) => 
       <section ref={ref} className={clsx(styles.hero, flush && styles.flush, className)}>
         <div className={styles.heroToolbar}>
           <BackButton>Back</BackButton>
-          <span className={styles.pokemonNumber}>{getDexNumber(pokemon.speciesId)}</span>
+          <div className={styles.heroMeta}>
+            <div className={styles.typesContainer}>
+              {pokemon.type.map((type: string) => (
+                <PokemonTypePill key={type} type={type} className={styles.heroPill} />
+              ))}
+            </div>
+            <span className={styles.pokemonNumber}>{getDexNumber(pokemon.speciesId)}</span>
+          </div>
         </div>
 
         <div className={styles.heroBody}>
@@ -66,11 +73,7 @@ export const PokemonHero = ({ pokemon, className, flush }: PokemonHeroProps) => 
               speciesId={pokemon.speciesId}
               speciesName={speciesName}
             />
-            <div className={styles.typesContainer}>
-              {pokemon.type.map((type: string) => (
-                <PokemonTypePill key={type} type={type} className={styles.heroPill} />
-              ))}
-            </div>
+            {pokemon.description && <p className={styles.description}>{pokemon.description}</p>}
           </div>
 
           <div className={styles.heroImage}>

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHeroSkeleton.module.css
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHeroSkeleton.module.css
@@ -29,6 +29,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
   padding: 0.75rem 1.5rem;
   background: rgba(0, 0, 0, 0.16);
@@ -41,7 +42,7 @@
   align-items: center;
   gap: 2rem;
   padding: 1.5rem 3rem;
-  max-height: 310px;
+  min-height: 310px;
   overflow: hidden;
 }
 
@@ -52,9 +53,29 @@
   gap: 0.75rem;
 }
 
+.heroMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  /* The toolbar wraps this cluster onto its own line once the type names get
+     long enough on a narrow viewport. space-between would park it at the start
+     of that line; auto keeps the number's hard-right anchor either way. */
+  margin-left: auto;
+  gap: 0.75rem;
+}
+
 .typesContainer {
   display: flex;
   gap: 0.5rem;
+}
+
+.description {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 52ch;
 }
 
 .heroImage {

--- a/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHeroSkeleton.tsx
+++ b/frontend/app/pokemon/[id]/components/PokemonHero/PokemonHeroSkeleton.tsx
@@ -13,7 +13,13 @@ export default function PokemonHeroSkeleton({ flush }: PokemonHeroSkeletonProps)
     <div className={clsx(styles.hero, flush && styles.flush)}>
       <div className={styles.heroToolbar}>
         <Skeleton variant="box" width={175} height={38} className={styles.onGradient} />
-        <Skeleton variant="line" width={64} height={30} className={styles.onGradient} />
+        <div className={styles.heroMeta}>
+          <div className={styles.typesContainer}>
+            <Skeleton variant="line" width={80} height={30} className={styles.onGradient} />
+            <Skeleton variant="line" width={80} height={30} className={styles.onGradient} />
+          </div>
+          <Skeleton variant="line" width={64} height={30} className={styles.onGradient} />
+        </div>
       </div>
       <div className={styles.heroBody}>
         <div className={styles.heroInfo}>
@@ -27,9 +33,19 @@ export default function PokemonHeroSkeleton({ flush }: PokemonHeroSkeletonProps)
             label="Loading Pokémon"
             className={styles.onGradient}
           />
-          <div className={styles.typesContainer}>
-            <Skeleton variant="line" width={80} height={30} className={styles.onGradient} />
-            <Skeleton variant="line" width={80} height={30} className={styles.onGradient} />
+          <div className={styles.description}>
+            <Skeleton
+              variant="line"
+              width="min(52ch, 100%)"
+              height={16}
+              className={styles.onGradient}
+            />
+            <Skeleton
+              variant="line"
+              width="min(38ch, 82%)"
+              height={16}
+              className={styles.onGradient}
+            />
           </div>
         </div>
         <div className={styles.heroImage}>

--- a/frontend/app/types/graphql.ts
+++ b/frontend/app/types/graphql.ts
@@ -84,6 +84,8 @@ export type PokedexDetail = {
 export type Pokemon = {
   abilities?: Maybe<Array<Ability>>;
   abilitiesLite: Array<AbilityLite>;
+  description?: Maybe<Scalars['String']['output']>;
+  descriptions?: Maybe<Array<PokemonDescription>>;
   evolution?: Maybe<EvolutionChain>;
   forms?: Maybe<Array<PokemonForm>>;
   id: Scalars['ID']['output'];
@@ -94,6 +96,11 @@ export type Pokemon = {
   speciesName: Scalars['String']['output'];
   stats: Stats;
   type: Array<Scalars['String']['output']>;
+};
+
+export type PokemonDescription = {
+  text: Scalars['String']['output'];
+  versions: Array<Scalars['String']['output']>;
 };
 
 /**


### PR DESCRIPTION
## Summary of changes

1. Introduced new fields for Pokémon descriptions in the GraphQL schema.
2. Implemented resolvers to fetch the latest description and all descriptions for each Pokémon.
3. Updated data sources to retrieve descriptions from the Pokémon API.
4. Added tests for the new description functionality.

## Steps to test

1. Verify that the GraphQL API returns the correct descriptions for Pokémon.
2. Ensure that the UI displays the descriptions appropriately.
